### PR TITLE
Implement Player stats and upgrades

### DIFF
--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -207,8 +207,3 @@ MonoBehaviour:
       baseValue: 15
       operation: 1
       scalingInBaseStat: []
-  - key: 20
-    def:
-      baseValue: 15
-      operation: 1
-      scalingInBaseStat: []

--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -75,3 +75,139 @@ MonoBehaviour:
     maxPerShopSlot: 4
     weight: 0
     maxPerInventorySlot: 10
+--- !u!114 &8408705079164422734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5066985577544289893}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ed6bc1b65f8b649f9e94a95e3dae9ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  definitions:
+  - key: 0
+    def:
+      baseValue: 3
+      operation: 1
+      scalingInBaseStat:
+      - stat: 5
+        value:
+        - 1
+        - 2
+        - 3
+        - 4
+  - key: 1
+    def:
+      baseValue: 2
+      operation: 1
+      scalingInBaseStat:
+      - stat: 5
+        value:
+        - 1
+        - 2
+        - 3
+        - 5
+      - stat: 3
+        value:
+        - 1
+        - 1.2
+        - 1.3
+        - 1.5
+  - key: 2
+    def:
+      baseValue: 0.4
+      operation: 1
+      scalingInBaseStat: []
+  - key: 3
+    def:
+      baseValue: 0.2
+      operation: 1
+      scalingInBaseStat: []
+  - key: 4
+    def:
+      baseValue: 0.1
+      operation: 1
+      scalingInBaseStat: []
+  - key: 5
+    def:
+      baseValue: 100
+      operation: 1
+      scalingInBaseStat: []
+  - key: 6
+    def:
+      baseValue: 3
+      operation: 1
+      scalingInBaseStat: []
+  - key: 6
+    def:
+      baseValue: 10
+      operation: 1
+      scalingInBaseStat: []
+  - key: 7
+    def:
+      baseValue: 5
+      operation: 1
+      scalingInBaseStat: []
+  - key: 8
+    def:
+      baseValue: 2.5
+      operation: 1
+      scalingInBaseStat: []
+  - key: 9
+    def:
+      baseValue: 3
+      operation: 1
+      scalingInBaseStat: []
+  - key: 10
+    def:
+      baseValue: 12
+      operation: 1
+      scalingInBaseStat: []
+  - key: 11
+    def:
+      baseValue: 100
+      operation: 1
+      scalingInBaseStat: []
+  - key: 12
+    def:
+      baseValue: 2
+      operation: 1
+      scalingInBaseStat: []
+  - key: 13
+    def:
+      baseValue: 1.5
+      operation: 1
+      scalingInBaseStat: []
+  - key: 14
+    def:
+      baseValue: 100
+      operation: 1
+      scalingInBaseStat: []
+  - key: 15
+    def:
+      baseValue: 5
+      operation: 1
+      scalingInBaseStat: []
+  - key: 16
+    def:
+      baseValue: 10
+      operation: 1
+      scalingInBaseStat: []
+  - key: 17
+    def:
+      baseValue: 20
+      operation: 1
+      scalingInBaseStat: []
+  - key: 18
+    def:
+      baseValue: 15
+      operation: 1
+      scalingInBaseStat: []
+  - key: 19
+    def:
+      baseValue: 15
+      operation: 1
+      scalingInBaseStat: []

--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3264794840061447751}
   - component: {fileID: 5196027272824433926}
+  - component: {fileID: 8408705079164422734}
   m_Layer: 0
   m_Name: Definitions
   m_TagString: Untagged
@@ -141,72 +142,72 @@ MonoBehaviour:
       baseValue: 3
       operation: 1
       scalingInBaseStat: []
-  - key: 6
-    def:
-      baseValue: 10
-      operation: 1
-      scalingInBaseStat: []
   - key: 7
     def:
-      baseValue: 5
+      baseValue: 10
       operation: 1
       scalingInBaseStat: []
   - key: 8
     def:
-      baseValue: 2.5
+      baseValue: 5
       operation: 1
       scalingInBaseStat: []
   - key: 9
     def:
-      baseValue: 3
+      baseValue: 5
       operation: 1
       scalingInBaseStat: []
   - key: 10
     def:
-      baseValue: 12
+      baseValue: 2.5
       operation: 1
       scalingInBaseStat: []
   - key: 11
     def:
-      baseValue: 100
+      baseValue: 12
       operation: 1
       scalingInBaseStat: []
   - key: 12
     def:
-      baseValue: 2
+      baseValue: 100
       operation: 1
       scalingInBaseStat: []
   - key: 13
     def:
-      baseValue: 1.5
+      baseValue: 2
       operation: 1
       scalingInBaseStat: []
   - key: 14
     def:
-      baseValue: 100
+      baseValue: 1.5
       operation: 1
       scalingInBaseStat: []
   - key: 15
     def:
-      baseValue: 5
+      baseValue: 100
       operation: 1
       scalingInBaseStat: []
   - key: 16
     def:
-      baseValue: 10
+      baseValue: 5
       operation: 1
       scalingInBaseStat: []
   - key: 17
     def:
-      baseValue: 20
+      baseValue: 10
       operation: 1
       scalingInBaseStat: []
   - key: 18
     def:
-      baseValue: 15
+      baseValue: 20
       operation: 1
       scalingInBaseStat: []
   - key: 19
+    def:
+      baseValue: 15
+      operation: 1
+      scalingInBaseStat: []
+  - key: 20
     def:
       baseValue: 15
       operation: 1

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -154,6 +154,8 @@ GameObject:
   - component: {fileID: 62203805369549304}
   - component: {fileID: 3948242591594315538}
   - component: {fileID: 8439484915624340096}
+  - component: {fileID: 1939592861400707939}
+  - component: {fileID: 1195309795827131598}
   m_Layer: 6
   m_Name: Player
   m_TagString: Untagged
@@ -170,7 +172,7 @@ Transform:
   m_GameObject: {fileID: 309834695554700441}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 36, y: 2, z: 27}
+  m_LocalPosition: {x: 92, y: 2, z: 3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -342,28 +344,6 @@ MonoBehaviour:
   projectiles:
   - {fileID: 7974811766441290857, guid: 60e49ade76f5c004293e0e18fd49dbb0, type: 3}
   weapon: {fileID: 5109643459192554882}
-  fireRate: 3
-  hitRate: 2
-  swingDuration: 0.4
-  strikeDuration: 0.2
-  returnDuration: 0.1
-  maxMana: 100
-  manaRegRate: 3
-  runSpeed: 15
-  walkSpeed: 5
-  sneakSpeed: 1
-  maxSlideTime: 3
-  slideSpeed: 12
-  maxHealth: 100
-  healthRegRate: 2
-  jumpHeight: 1.5
-  maxStamina: 100
-  staminaRegRate: 5
-  runConsRate: 10
-  slideConsRate: 20
-  jumpConsRate: 15
-  currentSlot: 0
-  itemDefinitions: {fileID: 0}
 --- !u!114 &8439484915624340096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,6 +357,31 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Inventory
   numItemSlots: 4
+--- !u!114 &1939592861400707939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 309834695554700441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 859ecc0f927b18dadb24872a7e65c545, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  levels: 
+--- !u!114 &1195309795827131598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 309834695554700441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99ff3bef177338594b0de52d0add7e5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerStats
 --- !u!1 &934793935829304382
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -837,6 +837,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e0350bcb2b86c54dbba9e5ecc7b4526, type: 3}
+--- !u!1001 &932034126
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 411.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 159
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264794840061447751, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5066985577544289893, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+      propertyPath: m_Name
+      value: Definitions
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
 --- !u!1001 &1086628912
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1635,3 +1692,4 @@ SceneRoots:
   - {fileID: 130924778}
   - {fileID: 1086628912}
   - {fileID: 8423912033985870804}
+  - {fileID: 932034126}

--- a/Assets/Scripts/DungeonCreator.cs
+++ b/Assets/Scripts/DungeonCreator.cs
@@ -35,8 +35,7 @@ public class DungeonCreator : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        if (itemDefinitions == null)
-            itemDefinitions = ItemDefinitions.main;
+        itemDefinitions = GameObject.Find("Definitions").GetComponent<ItemDefinitions>();
 
         navMeshSurface = GetComponent<NavMeshSurface>();
 

--- a/Assets/Scripts/GameSaver.cs
+++ b/Assets/Scripts/GameSaver.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.IO;
+
+class GameSaver
+{
+    private static List<WeakReference> saveables = new List<WeakReference>();
+    public static void subscribe<T>(T self)
+    {
+        var reference = new WeakReference(self);
+        saveables.Append(reference);
+        Debug.Log("Subscribed");
+    }
+
+    public static void save()
+    {
+        Debug.Log("start saving");
+        StreamWriter file = new StreamWriter("save.json");
+        file.WriteLine("#NotARougeLike savegame");
+        for (int i = 0; i < saveables.Count; i++)
+        {
+            var saveable = saveables[i];
+            //remove everyone that was subscribed but has been deleted since
+            if (!saveable.IsAlive)
+            {
+                saveables.RemoveAt(i--);
+                Debug.Log($"Removed dead. {i} remaining");
+                continue;
+            }
+            file.WriteLine(JsonUtility.ToJson(saveable.Target));
+
+        }
+        file.Close();
+        Debug.Log("finish saving");
+    }
+
+}

--- a/Assets/Scripts/GameSaver.cs.meta
+++ b/Assets/Scripts/GameSaver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fee16b60b1753bc9fa3c849ec29f6a69

--- a/Assets/Scripts/Items/ItemDefinitions.cs
+++ b/Assets/Scripts/Items/ItemDefinitions.cs
@@ -41,13 +41,6 @@ public class ItemDefinition {
 
 public class ItemDefinitions : MonoBehaviour
 {
-    // can be accessed as a singleton
-    public static ItemDefinitions main = null;
-
-    public ItemDefinitions() {
-        main = this;
-    }
-
     public ItemDefinition this[int i] {
         get => definitions[i];
     }

--- a/Assets/Scripts/Items/ItemHotbar.cs
+++ b/Assets/Scripts/Items/ItemHotbar.cs
@@ -19,7 +19,7 @@ public class ItemHotbar : MonoBehaviour
 
     void InitializeSlots() {
         
-        var numSlots = player.GetComponent<Inventory>().numItemSlots;
+        int numSlots = player.GetComponent<Inventory>().numItemSlots;
         slots = new GameObject[numSlots];
 
         for (int i = 0; i < numSlots; i++) {
@@ -31,7 +31,7 @@ public class ItemHotbar : MonoBehaviour
     void UpdateSlots() {
         var inv = player.GetComponent<Inventory>();
         for (int i = 0; i < slots.Length; i++) {
-            var slot = slots[i];
+            GameObject slot = slots[i];
             var s = slot.GetComponent<ItemHotbarSlot>();
             s.SetItem(inv.container[i].storedItem, inv.container[i].count);
             s.SetSelected(false);

--- a/Assets/Scripts/Items/ItemHotbar.cs
+++ b/Assets/Scripts/Items/ItemHotbar.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class ItemHotbar : MonoBehaviour
 {
-    public Player player;
+    private GameObject player;
 
     [Header("Rendering")]
     public GameObject slotPrefab;
@@ -13,8 +13,13 @@ public class ItemHotbar : MonoBehaviour
     // 
     private GameObject[] slots;
 
+    public void Awake() {
+        player = GameObject.Find("Player");
+    }
+
     void InitializeSlots() {
-        var numSlots = player.inventory.numItemSlots;
+        
+        var numSlots = player.GetComponent<Inventory>().numItemSlots;
         slots = new GameObject[numSlots];
 
         for (int i = 0; i < numSlots; i++) {
@@ -24,7 +29,7 @@ public class ItemHotbar : MonoBehaviour
     }
 
     void UpdateSlots() {
-        var inv = player.inventory;
+        var inv = player.GetComponent<Inventory>();
         for (int i = 0; i < slots.Length; i++) {
             var slot = slots[i];
             var s = slot.GetComponent<ItemHotbarSlot>();
@@ -37,7 +42,7 @@ public class ItemHotbar : MonoBehaviour
     void Update()
     {
         // check if slot count has changed
-        var numSlots = player.inventory.numItemSlots;
+        var numSlots = player.GetComponent<Inventory>().numItemSlots;
         if (slots == null || numSlots != slots.Length)
             InitializeSlots();
 

--- a/Assets/Scripts/Items/ShopItemSlot.cs
+++ b/Assets/Scripts/Items/ShopItemSlot.cs
@@ -17,7 +17,7 @@ public class ShopItemSlot : MonoBehaviour
         this.count = count;
         this.item = item;
 
-        var instance = Instantiate(item.itemModel, transform).transform;
+        Transform instance = Instantiate(item.itemModel, transform).transform;
         instance.localPosition = modelPosition;
         instance.localScale = modelScale;
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-[RequireComponent(typeof(CharacterController))]
+[RequireComponent(typeof(CharacterController)), RequireComponent(typeof(PlayerStats)), DisallowMultipleComponent]
 public class Player : MonoBehaviour
 {
     // Components
@@ -69,49 +69,17 @@ public class Player : MonoBehaviour
     [Header("Combat")]
     public Projectile[] projectiles;
     public Weapon weapon;
-    public float fireRate = 3.0f;
-    public float hitRate = 2.0f;
-    public float swingDuration = 0.4f;
-    public float strikeDuration = 0.2f;
-    public float returnDuration = 0.1f;
 
-    [Header("Mana")]
-    public float maxMana = 100.0f;
-    public float manaRegRate = 3.0f;
-
-    [Header("Movement")]
-    public float runSpeed = 10.0f;
-    public float walkSpeed = 5.0f;
-    public float sneakSpeed = 2.5f;
-
-    [Header("Sliding")]
-    public float maxSlideTime = 3.0f;
-    public float slideSpeed = 12.0f;
-
-    [Header("Health")]
-    public float maxHealth = 100.0f;
-    public float healthRegRate = 2.0f;
-
-    [Header("Jump")]
-    public float jumpHeight = 1.5f;
-
-    [Header("Stamina")]
-    public float maxStamina = 100.0f;
-    public float staminaRegRate = 5.0f;
-    public float runConsRate = 10.0f;
-    public float slideConsRate = 20.0f;
-    public float jumpConsRate = 15.0f;
-
-
-    [Header("Inventory")]
-    public Inventory inventory {get; private set;}
-
-    [SerializeField]
+    private Inventory inventory;
     private ItemDefinitions itemDefinitions;
+    private PlayerStats stats;
 
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    void Awake()
     {
+        stats = GetComponent<PlayerStats>();
+        inventory = GetComponent<Inventory>();
+        itemDefinitions = GameObject.Find("Definitions").GetComponent<ItemDefinitions>();
+
         GameObject mainCamera = GameObject.Find("Main Camera");
 
         playerCamera = mainCamera.GetComponent<Camera>();
@@ -121,13 +89,17 @@ public class Player : MonoBehaviour
 
         leftShoulderTransform = GameObject.Find("Left Shoulder").GetComponent<Transform>();
         rightShoulderTransform = GameObject.Find("Right Shoulder").GetComponent<Transform>();
+    }
 
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
         attackType = AttackType.Shoot;
         hitState = HitState.Idle;
 
-        currentHealth = maxHealth;
-        currentMana = maxMana;
-        currentStamina = maxStamina;
+        currentHealth = stats.maxHealth;
+        currentMana = stats.maxMana;
+        currentStamina = stats.maxStamina;
 
         fireCooldown = 0.0f;
         hitCooldown = 0.0f;
@@ -139,8 +111,6 @@ public class Player : MonoBehaviour
         defaultYScale = transform.localScale.y;
 
         weapon.gameObject.SetActive(false);
-
-        inventory = GetComponent<Inventory>();
     }
 
     // Update is called once per frame
@@ -183,8 +153,8 @@ public class Player : MonoBehaviour
         {
             hitTime += Time.deltaTime;
 
-            float duration = hitState == HitState.Swing ? swingDuration :
-                             hitState == HitState.Strike ? strikeDuration : returnDuration;
+            float duration = hitState == HitState.Swing ? stats.swingDuration :
+                             hitState == HitState.Strike ? stats.strikeDuration : stats.returnDuration;
 
             float ratio = Mathf.Clamp(hitTime / duration, 0.0f, 1.0f);
 
@@ -210,7 +180,7 @@ public class Player : MonoBehaviour
                         break;
                     case HitState.Return:
                         hitState = HitState.Idle;
-                        hitCooldown = 1.0f / hitRate;
+                        hitCooldown = 1.0f / stats.hitRate;
 
                         weapon.gameObject.SetActive(false);
                         break;
@@ -393,10 +363,10 @@ public class Player : MonoBehaviour
 
     public void Jump()
     {
-        if (grounded && currentStamina >= jumpConsRate)
+        if (grounded && currentStamina >= stats.jumpConsRate)
         {
-            currentStamina -= jumpConsRate;
-            motion.y = Mathf.Sqrt(jumpHeight * -2f * gravity);
+            currentStamina -= stats.jumpConsRate;
+            motion.y = Mathf.Sqrt(stats.jumpHeight * -2f * gravity);
         }
     }
 
@@ -405,21 +375,21 @@ public class Player : MonoBehaviour
         Vector3 movement = transform.right * direction.x + transform.forward * direction.y;
         movement.Normalize();
 
-        float speed = walkSpeed;
+        float speed = stats.walkSpeed;
 
-        if (run && currentStamina >= runConsRate)
+        if (run && currentStamina >= stats.runConsRate)
         {
-            currentStamina -= runConsRate * Time.deltaTime;
-            speed = runSpeed;
+            currentStamina -= stats.runConsRate * Time.deltaTime;
+            speed = stats.runSpeed;
         }
         else if (sneak)
         {
-            speed = sneakSpeed;
+            speed = stats.sneakSpeed;
         }
 
         if (slide)
         {
-            speed += slideSpeed * (slideTime / maxSlideTime);
+            speed += stats.slideSpeed * (slideTime / stats.maxSlideTime);
         }
 
         motion.x = movement.x * speed;
@@ -450,27 +420,27 @@ public class Player : MonoBehaviour
 
     void RegenerateHealth()
     {
-        if (currentHealth < maxHealth)
+        if (currentHealth < stats.maxHealth)
         {
-            float health = currentHealth + healthRegRate * Time.deltaTime;
-            currentHealth = Mathf.Min(health, maxHealth);
+            float health = currentHealth + stats.healthRegRate * Time.deltaTime;
+            currentHealth = Mathf.Min(health, stats.maxHealth);
         }
     }
 
     void RegenerateMana()
     {
-        if (currentMana < maxMana)
+        if (currentMana < stats.maxMana)
         {
-            float mana = currentMana + manaRegRate * Time.deltaTime;
-            currentMana = Mathf.Min(mana, maxMana);
+            float mana = currentMana + stats.manaRegRate * Time.deltaTime;
+            currentMana = Mathf.Min(mana, stats.maxMana);
         }
     }
 
     void RegenrerateStamina()
     {
-        if (currentStamina < maxStamina)
+        if (currentStamina < stats.maxStamina)
         {
-            float rate = staminaRegRate;
+            float rate = stats.staminaRegRate;
 
             if (motion.x >= -0.1f && motion.x <= 0.1f &&
                 motion.y >= -0.1f && motion.y <= 0.1f &&
@@ -481,7 +451,7 @@ public class Player : MonoBehaviour
             }
 
             float stamina = currentStamina + rate * Time.deltaTime;
-            currentStamina = Mathf.Min(stamina, maxStamina);
+            currentStamina = Mathf.Min(stamina, stats.maxStamina);
         }
     }
 
@@ -520,18 +490,18 @@ public class Player : MonoBehaviour
         instance.name = projectiles[0].name;
         instance.SetDamage(10.0f);
 
-        fireCooldown = 1.0f / fireRate;
+        fireCooldown = 1.0f / stats.fireRate;
     }
 
     public void Slide(bool value)
     {
-        if (value && currentStamina >= slideConsRate &&
+        if (value && currentStamina >= stats.slideConsRate &&
             grounded && !slide && slideCooldown == 0.0f)
         {
-            currentStamina -= slideConsRate;
+            currentStamina -= stats.slideConsRate;
 
             slide = true;
-            slideTime = maxSlideTime;
+            slideTime = stats.maxSlideTime;
         }
         else if (!value && slide)
         {
@@ -563,15 +533,15 @@ public class Player : MonoBehaviour
         {
             case "health_fruit": // Health Fruit
                 currentHealth += 30.0f;
-                currentHealth = Mathf.Clamp(currentHealth, 0.0f, maxHealth);
+                currentHealth = Mathf.Clamp(currentHealth, 0.0f, stats.maxHealth);
                 break;
             case "mana_fruit": // Mana Fruit
                 currentMana += 10.0f;
-                currentMana = Mathf.Clamp(currentMana, 0.0f, maxMana);
+                currentMana = Mathf.Clamp(currentMana, 0.0f, stats.maxMana);
                 break;
             case "stamina_fruit": // Stamina Fruit
                 currentStamina += 20.0f;
-                currentStamina = Mathf.Clamp(currentStamina, 0.0f, maxStamina);
+                currentStamina = Mathf.Clamp(currentStamina, 0.0f, stats.maxStamina);
                 break;
             default:
                 break;

--- a/Assets/Scripts/PlayerStats.meta
+++ b/Assets/Scripts/PlayerStats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ced7b7c52698909c9877c4460a5215f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerStats/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats/PlayerStats.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 
 
-/// stores player stats depending on player upgrades and items
+/// stores player stats depending on player upgrades and items.
 [RequireComponent(typeof(Inventory)), RequireComponent(typeof(PlayerUpgrades)), DisallowMultipleComponent]
 public class PlayerStats : MonoBehaviour
 {
@@ -28,7 +28,7 @@ public class PlayerStats : MonoBehaviour
         return def[stat].ComputeFrom(upgrades);
     }
 
-    // 
+    // should be called whenever player upgrades or inventory (or anything influencing stats) is modified
     public void Recompute() {
         fireRate = Compute(StatKey.FireRate); 
         hitRate = Compute(StatKey.HitRate); 
@@ -58,38 +58,38 @@ public class PlayerStats : MonoBehaviour
         jumpConsRate = Compute(StatKey.JumpConsRate); 
     }
 
-    // 
+    // conventient accessors for stats
     [Header("Combat")]
-    public float fireRate;
-    public float hitRate;
-    public float swingDuration;
-    public float strikeDuration;
-    public float returnDuration;
+    public float fireRate { get; private set; }
+    public float hitRate { get; private set; }
+    public float swingDuration { get; private set; }
+    public float strikeDuration { get; private set; }
+    public float returnDuration { get; private set; }
 
     [Header("Mana")]
-    public float maxMana;
-    public float manaRegRate;
+    public float maxMana { get; private set; }
+    public float manaRegRate { get; private set; }
 
     [Header("Movement")]
-    public float runSpeed;
-    public float walkSpeed;
-    public float sneakSpeed;
+    public float runSpeed { get; private set; }
+    public float walkSpeed { get; private set; }
+    public float sneakSpeed { get; private set; }
 
     [Header("Sliding")]
-    public float maxSlideTime;
-    public float slideSpeed;
+    public float maxSlideTime { get; private set; }
+    public float slideSpeed { get; private set; }
 
     [Header("Health")]
-    public float maxHealth;
-    public float healthRegRate;
+    public float maxHealth { get; private set; }
+    public float healthRegRate { get; private set; }
 
     [Header("Jump")]
-    public float jumpHeight;
+    public float jumpHeight { get; private set; }
 
     [Header("Stamina")]
-    public float maxStamina;
-    public float staminaRegRate;
-    public float runConsRate;
-    public float slideConsRate;
-    public float jumpConsRate;
+    public float maxStamina { get; private set; }
+    public float staminaRegRate { get; private set; }
+    public float runConsRate { get; private set; }
+    public float slideConsRate { get; private set; }
+    public float jumpConsRate { get; private set; }
 }

--- a/Assets/Scripts/PlayerStats/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats/PlayerStats.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+
+
+
+/// stores player stats depending on player upgrades and items
+[RequireComponent(typeof(Inventory)), RequireComponent(typeof(PlayerUpgrades)), DisallowMultipleComponent]
+public class PlayerStats : MonoBehaviour
+{
+    private StatScalingDefinitions def;
+    private PlayerUpgrades upgrades;
+    private Inventory inventory;
+
+    public void Start() {
+        def = GameObject.Find("Definitions").GetComponent<StatScalingDefinitions>();
+        upgrades = GetComponent<PlayerUpgrades>();
+        inventory = GetComponent<Inventory>();
+        Recompute();
+    }
+
+    public void Update() { 
+        // TODO: only when necessary
+        Recompute();
+    }
+
+    // 
+    private float Compute(StatKey stat) {
+        // TODO: check inventory for items with stat modifiers
+        return def[stat].ComputeFrom(upgrades);
+    }
+
+    // 
+    public void Recompute() {
+        fireRate = Compute(StatKey.FireRate); 
+        hitRate = Compute(StatKey.HitRate); 
+        swingDuration = Compute(StatKey.SwingDuration); 
+        strikeDuration = Compute(StatKey.StrikeDuration); 
+        returnDuration = Compute(StatKey.ReturnDuration); 
+
+        maxMana = Compute(StatKey.MaxMana); 
+        manaRegRate = Compute(StatKey.ManaRegRate); 
+
+        runSpeed = Compute(StatKey.RunSpeed); 
+        walkSpeed = Compute(StatKey.WalkSpeed); 
+        sneakSpeed = Compute(StatKey.SneakSpeed); 
+
+        maxSlideTime = Compute(StatKey.MaxSlideTime); 
+        slideSpeed = Compute(StatKey.SlideSpeed); 
+
+        maxHealth = Compute(StatKey.MaxHealth); 
+        healthRegRate = Compute(StatKey.HealthRegRate); 
+
+        jumpHeight = Compute(StatKey.JumpHeight); 
+
+        maxStamina = Compute(StatKey.MaxStamina); 
+        staminaRegRate = Compute(StatKey.StaminaRegRate); 
+        runConsRate = Compute(StatKey.RunConsRate); 
+        slideConsRate = Compute(StatKey.SlideConsRate); 
+        jumpConsRate = Compute(StatKey.JumpConsRate); 
+    }
+
+    // 
+    [Header("Combat")]
+    public float fireRate;
+    public float hitRate;
+    public float swingDuration;
+    public float strikeDuration;
+    public float returnDuration;
+
+    [Header("Mana")]
+    public float maxMana;
+    public float manaRegRate;
+
+    [Header("Movement")]
+    public float runSpeed;
+    public float walkSpeed;
+    public float sneakSpeed;
+
+    [Header("Sliding")]
+    public float maxSlideTime;
+    public float slideSpeed;
+
+    [Header("Health")]
+    public float maxHealth;
+    public float healthRegRate;
+
+    [Header("Jump")]
+    public float jumpHeight;
+
+    [Header("Stamina")]
+    public float maxStamina;
+    public float staminaRegRate;
+    public float runConsRate;
+    public float slideConsRate;
+    public float jumpConsRate;
+}

--- a/Assets/Scripts/PlayerStats/PlayerStats.cs.meta
+++ b/Assets/Scripts/PlayerStats/PlayerStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99ff3bef177338594b0de52d0add7e5e

--- a/Assets/Scripts/PlayerStats/PlayerUpgrades.cs
+++ b/Assets/Scripts/PlayerStats/PlayerUpgrades.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using System;
+
+public class PlayerUpgrades : MonoBehaviour
+{
+    [SerializeField]
+    private int[] levels;
+
+    public void Awake() {
+        levels = new int[Enum.GetValues(typeof(BaseStatKey)).Length];
+        foreach (BaseStatKey key in Enum.GetValues(typeof(BaseStatKey))) {
+            levels[(int)key] = 0;
+        }
+    }
+
+    public int this[BaseStatKey stat] {
+        get => levels[(int)stat];
+    }
+
+    public void Upgrade(BaseStatKey stat) {
+        levels[(int)stat] += 1;
+    }
+}

--- a/Assets/Scripts/PlayerStats/PlayerUpgrades.cs
+++ b/Assets/Scripts/PlayerStats/PlayerUpgrades.cs
@@ -3,6 +3,11 @@ using System;
 
 public class PlayerUpgrades : MonoBehaviour
 {
+    public PlayerUpgrades()
+    {
+        GameSaver.subscribe(this);
+    }
+
     [SerializeField]
     private int[] levels;
 
@@ -11,6 +16,7 @@ public class PlayerUpgrades : MonoBehaviour
         foreach (BaseStatKey key in Enum.GetValues(typeof(BaseStatKey))) {
             levels[(int)key] = 0;
         }
+        GameSaver.save();
     }
 
     public int this[BaseStatKey stat] {

--- a/Assets/Scripts/PlayerStats/PlayerUpgrades.cs.meta
+++ b/Assets/Scripts/PlayerStats/PlayerUpgrades.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 859ecc0f927b18dadb24872a7e65c545

--- a/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
+++ b/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
@@ -57,11 +57,11 @@ public class ScalingFormula {
         float result = baseValue;
         if (scalingInBaseStat != null) {
             if (operation == Operation.Multiplication) {
-                foreach (var s in scalingInBaseStat) {
+                foreach (Operand s in scalingInBaseStat) {
                     result *= s.value[upgradeLevels[s.stat]];
                 }
             } else {
-                foreach (var s in scalingInBaseStat) {
+                foreach (Operand s in scalingInBaseStat) {
                     result += s.value[upgradeLevels[s.stat]];
                 }
             }

--- a/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
+++ b/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using System;
 
+/// provides definitions on how to compute gameplay-stats from base-stats
+[DisallowMultipleComponent]
 public class StatScalingDefinitions : MonoBehaviour
 {
     [System.Serializable]
@@ -49,8 +51,13 @@ public class ScalingFormula {
     public enum Operation {
         Addition, Multiplication
     };
+
+    // initial value
     public float baseValue;
+
+    // how to combine operands
     public Operation operation;
+    // operand constists of a value per upgrade level of a base stat
     public Operand[] scalingInBaseStat;
 
     public float ComputeFrom(PlayerUpgrades upgradeLevels) {

--- a/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
+++ b/Assets/Scripts/PlayerStats/StatScalingDefinition.cs
@@ -1,0 +1,107 @@
+using UnityEngine;
+using System;
+
+public class StatScalingDefinitions : MonoBehaviour
+{
+    [System.Serializable]
+    public struct Def {
+        public StatKey key;
+        public ScalingFormula def;
+    };
+
+    // for editor
+    [SerializeField]
+    private Def[] definitions;
+
+    // optimized datastructure
+    private ScalingFormula[] _defs;
+
+    // put definitions into an array
+    public void Awake() {
+        _defs = new ScalingFormula[Enum.GetValues(typeof(StatKey)).Length];
+        foreach (Def d in definitions) {
+            _defs[(int)d.key] = d.def;
+        }
+
+        // check definitions
+        for (int i = 0; i < _defs.Length; i++) {
+            if (_defs[i] == null) Debug.Log("scaling undefined for " + Enum.GetName(typeof(StatKey), (StatKey) i));
+        }
+    }
+
+    public ScalingFormula this[StatKey stat] {
+        get => _defs[(int)stat];
+    }
+}
+
+
+[System.Serializable]
+public class ScalingFormula {
+    [System.Serializable]
+    public struct Operand {
+        [Tooltip("The base stat to depend on")]
+        public BaseStatKey stat;
+        [Tooltip("value for each upgrade level")]
+        public float[] value;
+    }
+
+    // defines how the values should be combined
+    public enum Operation {
+        Addition, Multiplication
+    };
+    public float baseValue;
+    public Operation operation;
+    public Operand[] scalingInBaseStat;
+
+    public float ComputeFrom(PlayerUpgrades upgradeLevels) {
+        float result = baseValue;
+        if (scalingInBaseStat != null) {
+            if (operation == Operation.Multiplication) {
+                foreach (var s in scalingInBaseStat) {
+                    result *= s.value[upgradeLevels[s.stat]];
+                }
+            } else {
+                foreach (var s in scalingInBaseStat) {
+                    result += s.value[upgradeLevels[s.stat]];
+                }
+            }
+        }
+        return result;
+    }
+}
+
+// base stats that can be upgraded
+public enum BaseStatKey {
+    Health,
+    Armour,
+    Strength,
+    Agility,
+    Stamina,
+    Dexterity,
+    Perception
+}
+
+// stats that are relevant to gameplay and depend on base stats
+public enum StatKey {
+    FireRate,
+    HitRate,
+    SwingDuration,
+    StrikeDuration,
+    ReturnDuration,
+    MaxMana,
+    ManaRegRate,
+    RunSpeed,
+    WalkSpeed,
+    SneakSpeed,
+    MaxSlideTime,
+    SlideSpeed,
+    MaxHealth,
+    HealthRegRate,
+    JumpHeight,
+    MaxStamina,
+    StaminaRegRate,
+    RunConsRate,
+    SlideConsRate,
+    JumpConsRate
+}
+

--- a/Assets/Scripts/PlayerStats/StatScalingDefinition.cs.meta
+++ b/Assets/Scripts/PlayerStats/StatScalingDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ed6bc1b65f8b649f9e94a95e3dae9ac

--- a/Assets/Scripts/ShopRenderer.cs
+++ b/Assets/Scripts/ShopRenderer.cs
@@ -6,7 +6,7 @@ using TMPro;
 public class ShopRenderer : MonoBehaviour
 {
     [System.Serializable]
-    public struct ItemSlot {
+    public struct ItemSlotConfig {
         public Vector3 position;
     }
 
@@ -19,7 +19,7 @@ public class ShopRenderer : MonoBehaviour
 
 
     [Header("Rendering")]
-    public ItemSlot[] slotProperties;
+    public ItemSlotConfig[] slotProperties;
     public GameObject itemSlotPrefab;
     // where to instantiate item slots
     public Transform slotDisplayParent;
@@ -41,7 +41,7 @@ public class ShopRenderer : MonoBehaviour
             if (slot.storedItem == null) {
                 // no item
             } else {
-                var slotInstance = Instantiate(itemSlotPrefab, slotDisplayParent).transform;
+                Transform slotInstance = Instantiate(itemSlotPrefab, slotDisplayParent).transform;
                 slotInstance.localPosition = slotDisplay.position;
                 slotInstance.GetComponent<ShopItemSlot>().SetItem(slot.storedItem, slot.count);
             }
@@ -50,11 +50,11 @@ public class ShopRenderer : MonoBehaviour
 
     // TODO: extract to dungeon creator
     public void AddRandomItems() {
-        foreach (var slot in items.slots) {
+        foreach (ItemSlot slot in items.slots) {
             slot.storedItem = null;
 
             // select random definition
-            var random = UnityEngine.Random.Range(0f,1f);
+            float random = UnityEngine.Random.Range(0f,1f);
             foreach (ItemDefinition def in itemDefinitions.definitions) {
                 if (random <= def.shopProbability) {
                     slot.storedItem = def;

--- a/Assets/Scripts/ShopRenderer.cs
+++ b/Assets/Scripts/ShopRenderer.cs
@@ -27,8 +27,7 @@ public class ShopRenderer : MonoBehaviour
 
 
     public void Awake() {
-        if (itemDefinitions == null)
-            itemDefinitions = ItemDefinitions.main;
+        itemDefinitions = GameObject.Find("Definitions").GetComponent<ItemDefinitions>();
 
         items = new(numItemSlots);
     }

--- a/Assets/Scripts/UserInterface.cs
+++ b/Assets/Scripts/UserInterface.cs
@@ -9,31 +9,27 @@ public class UserInterface : MonoBehaviour
     private Slider staminaBar;
 
     private Player player;
+    private PlayerStats playerStats;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
         player = GameObject.Find("Player").GetComponent<Player>();
+        playerStats = GameObject.Find("Player").GetComponent<PlayerStats>();
         
         healthBar = GameObject.Find("Health Bar").GetComponent<Slider>();
-        healthBar.maxValue = player.maxHealth;
-        healthBar.value = player.GetHealth();
-
         manaBar = GameObject.Find("Mana Bar").GetComponent<Slider>();
-        manaBar.maxValue = player.maxMana;
-        manaBar.value = player.GetMana();
-
         staminaBar = GameObject.Find("Stamina Bar").GetComponent<Slider>();
-        staminaBar.maxValue = player.maxStamina;
-        staminaBar.value = player.GetStamina();
-        
     }
 
     // Update is called once per frame
     void Update()
     {
+        healthBar.maxValue = playerStats.maxHealth;
         healthBar.value = player.GetHealth();
+        manaBar.maxValue = playerStats.maxMana;
         manaBar.value = player.GetMana();
+        staminaBar.maxValue = playerStats.maxStamina;
         staminaBar.value = player.GetStamina();
     }
 }


### PR DESCRIPTION
Implements player stats and upgrades.

The implementation distinguishes between base-stats (that can be upgraded) and gameplay stats (that depend on the upgrade levels of base-stats).
Dependence of gameplay stats (e.g. attack rate, health regeneration, ...) can be defined using the StatScalingDefinitions-Component (attached to the Definitions-Prefab).

The upgrade levels of base stats are simply represented by integers and stored in the PlayerUpgrades-Component.

The PlayerStats component mainly acts as a interface to access gameplay-stats, applying the scaling definitions to the actual base-stat-Levels.


Improves #13 