### PR TITLE
Crosshair, Interaction hints and improvements to projectiles

### DIFF
--- a/Assets/Prefabs/BowAmmo.prefab
+++ b/Assets/Prefabs/BowAmmo.prefab
@@ -1,78 +1,24 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3299236393378255261
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2150928154422146897}
-  - component: {fileID: 4382438909386837003}
-  m_Layer: 0
-  m_Name: BowAmmo
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2150928154422146897
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3299236393378255261}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7713562671212033608}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &4382438909386837003
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3299236393378255261}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.5, y: 0.5, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &7820128142587269539
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2150928154422146897}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalScale.x
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalScale.y
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalScale.z
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalPosition.x
@@ -84,15 +30,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalRotation.y
@@ -104,7 +50,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -116,15 +62,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_Name
-      value: Arrow
+      value: BowAmmo
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5cd765b255372084db586f176fb14f01, type: 3}
---- !u!4 &7713562671212033608 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
-  m_PrefabInstance: {fileID: 7820128142587269539}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Canvas.prefab
+++ b/Assets/Prefabs/Canvas.prefab
@@ -651,6 +651,194 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &4467586197999952307
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5655639655497101022}
+  - component: {fileID: 9031358313704703657}
+  - component: {fileID: 1695035330280261398}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5655639655497101022
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4467586197999952307}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6861916810538353793}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 50, y: 0}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &9031358313704703657
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4467586197999952307}
+  m_CullTransparentMesh: 1
+--- !u!114 &1695035330280261398
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4467586197999952307}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4574222539688569164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6861916810538353793}
+  - component: {fileID: 1549906725759458579}
+  m_Layer: 5
+  m_Name: Crosshair
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6861916810538353793
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4574222539688569164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3460427086511222036}
+  - {fileID: 5655639655497101022}
+  m_Father: {fileID: 7299883490974400925}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1549906725759458579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4574222539688569164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b1b264d8adc6151caa83d63bd8d45c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  icon: {fileID: 336460331223615983}
+  text: {fileID: 1695035330280261398}
 --- !u!1 &4727667363860691747
 GameObject:
   m_ObjectHideFlags: 0
@@ -1451,6 +1639,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6503310361013520092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3460427086511222036}
+  - component: {fileID: 508812747969998500}
+  - component: {fileID: 336460331223615983}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3460427086511222036
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6503310361013520092}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6861916810538353793}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 8, y: 8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &508812747969998500
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6503310361013520092}
+  m_CullTransparentMesh: 1
+--- !u!114 &336460331223615983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6503310361013520092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6604585696037067225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1502,7 +1765,6 @@ GameObject:
   - component: {fileID: 7128067112286998707}
   - component: {fileID: 4840845350211867440}
   - component: {fileID: 1174493148950342287}
-  - component: {fileID: 2463772989703623287}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1528,6 +1790,7 @@ RectTransform:
   - {fileID: 8922166085170856251}
   - {fileID: 4272778915715390304}
   - {fileID: 854983740755527331}
+  - {fileID: 6861916810538353793}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1611,6 +1874,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::UserInput
   mouseSensitivity: 0.1
+  stickSensitivity: 150
 --- !u!114 &1174493148950342287
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -263,7 +263,7 @@ MonoBehaviour:
   hotbarSlots: 4
   initialGold: 5
   initialXP: 0
-  initialAmmo: 256
+  initialAmmo: 16
 --- !u!114 &7895014659698534790
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -81,8 +81,8 @@ MonoBehaviour:
     maxPerInventorySlot: 10
   - name: BowAmmo
     displayName: Bow Ammo
-    itemModel: {fileID: 3299236393378255261, guid: 4bc641c7358486c479b67cdc7d794936, type: 3}
-    itemModelUI: {fileID: 3299236393378255261, guid: 4bc641c7358486c479b67cdc7d794936, type: 3}
+    itemModel: {fileID: 6937730135751535858, guid: 4bc641c7358486c479b67cdc7d794936, type: 3}
+    itemModelUI: {fileID: 6937730135751535858, guid: 4bc641c7358486c479b67cdc7d794936, type: 3}
     dropProbability: 0.39
     shopProbability: 0.31
     cost: 2

--- a/Assets/Prefabs/Environment/large_chest.prefab
+++ b/Assets/Prefabs/Environment/large_chest.prefab
@@ -56,40 +56,35 @@ PrefabInstance:
       propertyPath: m_Name
       value: large_chest
       objectReference: {fileID: 0}
+    - target: {fileID: 1521579425286674091, guid: e7b9dbe30139672529e028327be50597, type: 3}
+      propertyPath: m_Size.x
+      value: 1.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 1521579425286674091, guid: e7b9dbe30139672529e028327be50597, type: 3}
+      propertyPath: m_Size.z
+      value: 1.05
+      objectReference: {fileID: 0}
     - target: {fileID: 2256668696731105702, guid: e7b9dbe30139672529e028327be50597, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.06454489
+      objectReference: {fileID: 0}
+    - target: {fileID: 2353983902424605660, guid: e7b9dbe30139672529e028327be50597, type: 3}
+      propertyPath: m_Extents.x
+      value: 0.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 2353983902424605660, guid: e7b9dbe30139672529e028327be50597, type: 3}
+      propertyPath: m_Extents.z
+      value: 0.525
       objectReference: {fileID: 0}
     - target: {fileID: 2622840580407919122, guid: e7b9dbe30139672529e028327be50597, type: 3}
       propertyPath: droppedItemPrefab
       value: 
       objectReference: {fileID: 6834112976765427387, guid: 5c8515f40aecf6259b9c3cdb74d0a499, type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5767974309510853132, guid: e7b9dbe30139672529e028327be50597, type: 3}
+    - {fileID: 898926249135683563, guid: e7b9dbe30139672529e028327be50597, type: 3}
+    - {fileID: 6439392329031797383, guid: e7b9dbe30139672529e028327be50597, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 801789873906574201, guid: e7b9dbe30139672529e028327be50597, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8994700406994057102}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e7b9dbe30139672529e028327be50597, type: 3}
---- !u!1 &3755158828780754784 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 801789873906574201, guid: e7b9dbe30139672529e028327be50597, type: 3}
-  m_PrefabInstance: {fileID: 4556946468209095705}
-  m_PrefabAsset: {fileID: 0}
---- !u!208 &8994700406994057102
-NavMeshObstacle:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3755158828780754784}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Shape: 1
-  m_Extents: {x: 0.55, y: 0.55, z: 0.55}
-  m_MoveThreshold: 0.1
-  m_Carve: 1
-  m_CarveOnlyStationary: 1
-  m_Center: {x: 0, y: 0.15, z: 0}
-  m_TimeToStationary: 0.5

--- a/Assets/Prefabs/Environment/small_chest.prefab
+++ b/Assets/Prefabs/Environment/small_chest.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 3066716598494785066}
   - component: {fileID: 4863019246393371001}
   - component: {fileID: 7936785592263926177}
-  - component: {fileID: 6439392329031797383}
   m_Layer: 0
   m_Name: chest_body
   m_TagString: Untagged
@@ -90,27 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &6439392329031797383
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 552132564688745304}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &801789873906574201
 GameObject:
   m_ObjectHideFlags: 0
@@ -122,6 +100,8 @@ GameObject:
   - component: {fileID: 798515110419488166}
   - component: {fileID: 2353983902424605660}
   - component: {fileID: 2622840580407919122}
+  - component: {fileID: 1521579425286674091}
+  - component: {fileID: 4419287533018641789}
   m_Layer: 0
   m_Name: small_chest
   m_TagString: Untagged
@@ -157,7 +137,7 @@ NavMeshObstacle:
   m_Enabled: 1
   serializedVersion: 3
   m_Shape: 1
-  m_Extents: {x: 0.55, y: 0.55, z: 0.55}
+  m_Extents: {x: 0.55, y: 0.5, z: 0.55}
   m_MoveThreshold: 0.1
   m_Carve: 1
   m_CarveOnlyStationary: 1
@@ -177,6 +157,40 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::DestroyableObject
   maxHealth: 50
   droppedItemPrefab: {fileID: 6834112976765427387, guid: 5c8515f40aecf6259b9c3cdb74d0a499, type: 3}
+--- !u!65 &1521579425286674091
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 801789873906574201}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.1, y: 1, z: 1.1}
+  m_Center: {x: 0, y: 0.15, z: 0}
+--- !u!114 &4419287533018641789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 801789873906574201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e227e6af1d2a503c7846a56c901df237, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AttachedObjects
+  maximumAttachedObjects: 10
 --- !u!1 &3442830045073502725
 GameObject:
   m_ObjectHideFlags: 0
@@ -188,7 +202,6 @@ GameObject:
   - component: {fileID: 5636041556457779554}
   - component: {fileID: 6075277654179138944}
   - component: {fileID: 7969333999713203676}
-  - component: {fileID: 898926249135683563}
   m_Layer: 0
   m_Name: chest_top
   m_TagString: Untagged
@@ -267,27 +280,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &898926249135683563
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3442830045073502725}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8264477999877221482
 GameObject:
   m_ObjectHideFlags: 0
@@ -299,7 +291,6 @@ GameObject:
   - component: {fileID: 2256668696731105702}
   - component: {fileID: 6104743834362747885}
   - component: {fileID: 6797944144903086027}
-  - component: {fileID: 5767974309510853132}
   m_Layer: 0
   m_Name: chest_lock
   m_TagString: Untagged
@@ -378,24 +369,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &5767974309510853132
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8264477999877221482}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/ItemPrefabs/health_fruit.prefab
+++ b/Assets/Prefabs/ItemPrefabs/health_fruit.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 6035457373218364336}
   - component: {fileID: 6678656224662204042}
   - component: {fileID: 5077448716351379217}
-  - component: {fileID: 1853721955655632527}
   m_Layer: 0
   m_Name: body
   m_TagString: Untagged
@@ -29,7 +28,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.7960089, y: 0.7960089, z: 0.7960089}
+  m_LocalScale: {x: 0.39800444, y: 0.39800444, z: 0.39800444}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4318507895472737666}
@@ -90,27 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &1853721955655632527
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 37707321540172294}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3894232915696125751
 GameObject:
   m_ObjectHideFlags: 0
@@ -122,7 +100,6 @@ GameObject:
   - component: {fileID: 321176834380227312}
   - component: {fileID: 9076180512647653536}
   - component: {fileID: 77592194555121024}
-  - component: {fileID: 5511800171451093642}
   m_Layer: 0
   m_Name: neck
   m_TagString: Untagged
@@ -139,8 +116,8 @@ Transform:
   m_GameObject: {fileID: 3894232915696125751}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.326, z: 0}
-  m_LocalScale: {x: 0.10740813, y: 0.32056758, z: 0.1450349}
+  m_LocalPosition: {x: 0, y: 0.163, z: 0}
+  m_LocalScale: {x: 0.05370405, y: 0.1602838, z: 0.07251745}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4318507895472737666}
@@ -201,29 +178,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &5511800171451093642
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3894232915696125751}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5994598806465713049
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,6 +187,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4318507895472737666}
+  - component: {fileID: 6662445752637224613}
   m_Layer: 0
   m_Name: health_fruit
   m_TagString: Untagged
@@ -257,3 +212,24 @@ Transform:
   - {fileID: 6035457373218364336}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &6662445752637224613
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5994598806465713049}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.2
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/ItemPrefabs/mana_fruit.prefab
+++ b/Assets/Prefabs/ItemPrefabs/mana_fruit.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 5767644851383992517}
   - component: {fileID: 698214625654780684}
   - component: {fileID: 3890352196648746087}
-  - component: {fileID: 8188082764470132239}
   m_Layer: 0
   m_Name: neck
   m_TagString: Untagged
@@ -28,8 +27,8 @@ Transform:
   m_GameObject: {fileID: 45770046735742014}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.326, z: 0}
-  m_LocalScale: {x: 0.10740813, y: 0.32056758, z: 0.1450349}
+  m_LocalPosition: {x: 0, y: 0.163, z: 0}
+  m_LocalScale: {x: 0.05370405, y: 0.1602838, z: 0.07251745}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3004185048417500518}
@@ -90,29 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &8188082764470132239
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 45770046735742014}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &642601510036366421
 GameObject:
   m_ObjectHideFlags: 0
@@ -124,7 +100,6 @@ GameObject:
   - component: {fileID: 5749061817842169683}
   - component: {fileID: 3161215627873634239}
   - component: {fileID: 6105037880839242416}
-  - component: {fileID: 1089585334515052021}
   m_Layer: 0
   m_Name: body
   m_TagString: Untagged
@@ -142,7 +117,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.7960089, y: 0.7960089, z: 0.7960089}
+  m_LocalScale: {x: 0.39800444, y: 0.39800444, z: 0.39800444}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3004185048417500518}
@@ -203,27 +178,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &1089585334515052021
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642601510036366421}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8399732216031229202
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,6 +187,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3004185048417500518}
+  - component: {fileID: -6438622749468703042}
   m_Layer: 0
   m_Name: mana_fruit
   m_TagString: Untagged
@@ -257,3 +212,24 @@ Transform:
   - {fileID: 5749061817842169683}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &-6438622749468703042
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8399732216031229202}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.2
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/ItemPrefabs/stamina_fruit.prefab
+++ b/Assets/Prefabs/ItemPrefabs/stamina_fruit.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7056376686764096210}
+  - component: {fileID: 1458440536577574279}
   m_Layer: 0
   m_Name: stamina_fruit
   m_TagString: Untagged
@@ -33,6 +34,27 @@ Transform:
   - {fileID: 8686897441914012088}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &1458440536577574279
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1662156151352070245}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.2
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3762638555259217851
 GameObject:
   m_ObjectHideFlags: 0
@@ -44,7 +66,6 @@ GameObject:
   - component: {fileID: 8686897441914012088}
   - component: {fileID: 5307847778511610399}
   - component: {fileID: 4069174554859806468}
-  - component: {fileID: 4380746478186107690}
   m_Layer: 0
   m_Name: body
   m_TagString: Untagged
@@ -62,7 +83,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.7960089, y: 0.7960089, z: 0.7960089}
+  m_LocalScale: {x: 0.39800444, y: 0.39800444, z: 0.39800444}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7056376686764096210}
@@ -123,27 +144,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &4380746478186107690
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3762638555259217851}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5275186874110319352
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,7 +155,6 @@ GameObject:
   - component: {fileID: 4650342960833759713}
   - component: {fileID: 2899706038397173090}
   - component: {fileID: 6451083529527600026}
-  - component: {fileID: 4016332415185995381}
   m_Layer: 0
   m_Name: neck
   m_TagString: Untagged
@@ -172,8 +171,8 @@ Transform:
   m_GameObject: {fileID: 5275186874110319352}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.326, z: 0}
-  m_LocalScale: {x: 0.10740813, y: 0.32056758, z: 0.1450349}
+  m_LocalPosition: {x: 0, y: 0.163, z: 0}
+  m_LocalScale: {x: 0.05370405, y: 0.1602838, z: 0.07251745}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7056376686764096210}
@@ -234,26 +233,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &4016332415185995381
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5275186874110319352}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Opponent.prefab
+++ b/Assets/Prefabs/Opponent.prefab
@@ -2166,6 +2166,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::AttachedObjects
   maximumAttachedObjects: 10
   mesh: {fileID: 5764523598682308999}
+  boneSnappingFactor: 0.7
 --- !u!1 &8673311879040220446
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Opponent.prefab
+++ b/Assets/Prefabs/Opponent.prefab
@@ -2026,6 +2026,7 @@ GameObject:
   - component: {fileID: 4975561014754260319}
   - component: {fileID: 7261524907011688642}
   - component: {fileID: 2506817616126039836}
+  - component: {fileID: 7685539837612636914}
   m_Layer: 0
   m_Name: Opponent
   m_TagString: Untagged
@@ -2151,6 +2152,20 @@ MonoBehaviour:
   wanderRadius: 5
   viewAngle: 60
   memoryDuration: 5
+--- !u!114 &7685539837612636914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8282398908945130151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 52725cfa5a14fa803b3a1ba42ecf7fa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::AttachedObjects
+  maximumAttachedObjects: 10
+  mesh: {fileID: 5764523598682308999}
 --- !u!1 &8673311879040220446
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -177,7 +177,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4453946537051165443}
-  - {fileID: 4689451027459723874}
   - {fileID: 6962532261219207549}
   - {fileID: 3731031123254797858}
   - {fileID: 4312503172612061165}
@@ -358,6 +357,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 859ecc0f927b18dadb24872a7e65c545, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
+  levels:
+    levels: 00000000000000000000000000000000000000000000000000000000
 --- !u!114 &1195309795827131598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -413,73 +414,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7159259200340361328}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1882290135256068362
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4689451027459723874}
-  - component: {fileID: 8703256769441506137}
-  - component: {fileID: 6976849159132783074}
-  m_Layer: 6
-  m_Name: Interaction Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4689451027459723874
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882290135256068362}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4364760115977151773}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &8703256769441506137
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882290135256068362}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 2, y: 1, z: 2}
-  m_Center: {x: 0, y: -0.5, z: 1.5}
---- !u!114 &6976849159132783074
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882290135256068362}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 21ad01efd6a9275439bdaca604ec6f30, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: '::'
-  triggerObject: {fileID: 0}
 --- !u!1 &1993501791673906359
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Projectile.prefab
+++ b/Assets/Prefabs/Projectile.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 2150928154422146897}
   - component: {fileID: 3325971709186474981}
   - component: {fileID: 7974811766441290857}
-  - component: {fileID: 4608341986017277947}
   m_Layer: 0
   m_Name: Projectile
   m_TagString: Untagged
@@ -75,30 +74,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Projectile
   droppedItemPrefab: {fileID: 6834112976765427387, guid: 5c8515f40aecf6259b9c3cdb74d0a499, type: 3}
-  speed: 25
+  speed: 100
   lifetime: 30
   tipPosition: {x: 0, y: 0, z: 1.2}
---- !u!65 &4608341986017277947
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3299236393378255261}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.5, y: 0.5, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &7820128142587269539
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Projectile.prefab
+++ b/Assets/Prefabs/Projectile.prefab
@@ -76,7 +76,7 @@ MonoBehaviour:
   droppedItemPrefab: {fileID: 6834112976765427387, guid: 5c8515f40aecf6259b9c3cdb74d0a499, type: 3}
   speed: 100
   lifetime: 30
-  tipPosition: {x: 0, y: 0, z: 1.2}
+  tipPosition: {x: 0, y: 0, z: 3}
 --- !u!1001 &7820128142587269539
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -107,7 +107,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5cd765b255372084db586f176fb14f01, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/Projectile.prefab
+++ b/Assets/Prefabs/Projectile.prefab
@@ -77,6 +77,7 @@ MonoBehaviour:
   droppedItemPrefab: {fileID: 6834112976765427387, guid: 5c8515f40aecf6259b9c3cdb74d0a499, type: 3}
   speed: 25
   lifetime: 30
+  tipPosition: {x: 0, y: 0, z: 1.2}
 --- !u!65 &4608341986017277947
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Shop/DroppedItem.prefab
+++ b/Assets/Prefabs/Shop/DroppedItem.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 5107533188061079315}
   - component: {fileID: 8158723005185026922}
   - component: {fileID: -8092010828048132742}
-  - component: {fileID: 5107533188061079315}
   m_Layer: 0
   m_Name: DroppedItem
   m_TagString: Untagged
@@ -52,6 +51,7 @@ MonoBehaviour:
   modelPosition: {x: 0, y: 0, z: 0}
   modelScale: {x: 1, y: 1, z: 1}
   modelRotation: {x: -0.70710677, y: 0, z: 0, w: 0.70710677}
+  interactionHintFormat: Pick up {0}
 --- !u!114 &8690330570862342540
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -101,6 +101,11 @@ BoxCollider:
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &-8092010828048132742
 Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6834112976765427387}
   serializedVersion: 5
   m_Mass: 1
   m_LinearDamping: 0

--- a/Assets/Prefabs/Shop/DroppedItem.prefab
+++ b/Assets/Prefabs/Shop/DroppedItem.prefab
@@ -10,8 +10,11 @@ GameObject:
   m_Component:
   - component: {fileID: 1576648743897872727}
   - component: {fileID: 4071575476924804543}
-  - component: {fileID: 5798305150980407684}
-  - component: {fileID: 5305657949154678974}
+  - component: {fileID: 8690330570862342540}
+  - component: {fileID: 5107533188061079315}
+  - component: {fileID: 8158723005185026922}
+  - component: {fileID: -8092010828048132742}
+  - component: {fileID: 5107533188061079315}
   m_Layer: 0
   m_Name: DroppedItem
   m_TagString: Untagged
@@ -28,7 +31,7 @@ Transform:
   m_GameObject: {fileID: 6834112976765427387}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.31965, y: 0, z: 6.37081}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -47,9 +50,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   modelPosition: {x: 0, y: 0, z: 0}
-  modelScale: {x: 0.4, y: 0.4, z: 0.4}
-  modelRotation: {x: 0, y: 0, z: 0, w: 0}
---- !u!65 &5798305150980407684
+  modelScale: {x: 1, y: 1, z: 1}
+  modelRotation: {x: -0.70710677, y: 0, z: 0, w: 0.70710677}
+--- !u!114 &8690330570862342540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6834112976765427387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 539227d16cd76d24e9acd4b28d4b9daa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InteractionHint
+  Text: Pick up
+--- !u!114 &5107533188061079315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6834112976765427387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9b7b4dc7e378fb5397ae934a4737e8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Attachable
+  attachedTo: {fileID: 0}
+--- !u!65 &8158723005185026922
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -64,22 +93,31 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &5305657949154678974
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6834112976765427387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 539227d16cd76d24e9acd4b28d4b9daa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::InteractionHint
-  Text: Pick up
+--- !u!54 &-8092010828048132742
+Rigidbody:
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/Prefabs/Shop/DroppedItem.prefab
+++ b/Assets/Prefabs/Shop/DroppedItem.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1576648743897872727}
   - component: {fileID: 4071575476924804543}
   - component: {fileID: 5798305150980407684}
+  - component: {fileID: 5305657949154678974}
   m_Layer: 0
   m_Name: DroppedItem
   m_TagString: Untagged
@@ -47,6 +48,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   modelPosition: {x: 0, y: 0, z: 0}
   modelScale: {x: 0.4, y: 0.4, z: 0.4}
+  modelRotation: {x: 0, y: 0, z: 0, w: 0}
 --- !u!65 &5798305150980407684
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -68,3 +70,16 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5305657949154678974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6834112976765427387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 539227d16cd76d24e9acd4b28d4b9daa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InteractionHint
+  Text: Pick up

--- a/Assets/Prefabs/Shop/ItemSlot.prefab
+++ b/Assets/Prefabs/Shop/ItemSlot.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3149326417299643767}
   - component: {fileID: 2991341889146743818}
   - component: {fileID: 9102281271320279951}
+  - component: {fileID: 7629709023343499507}
   m_Layer: 0
   m_Name: ItemSlot
   m_TagString: Untagged
@@ -32,7 +33,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6953813559093887542}
-  - {fileID: 5547802485691143203}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &2991341889146743818
@@ -54,7 +54,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.3, y: 0.3, z: 0.1}
+  m_Size: {x: 0.4, y: 0.4, z: 0.1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &9102281271320279951
 MonoBehaviour:
@@ -69,97 +69,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   modelPosition: {x: 0, y: 0, z: 0}
-  modelScale: {x: 0.1, y: 0.1, z: 0.1}
+  modelScale: {x: 0.4, y: 0.4, z: 0.4}
   costText: {fileID: 4050262901591825956}
---- !u!1 &2250339879979335594
-GameObject:
+  shop: {fileID: 0}
+  Index: 0
+--- !u!114 &7629709023343499507
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5547802485691143203}
-  - component: {fileID: 5968602274900620474}
-  - component: {fileID: 4851144345488517393}
-  m_Layer: 0
-  m_Name: Model
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5547802485691143203
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2250339879979335594}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0.1}
-  m_LocalScale: {x: 0.3, y: 0.05, z: 0.3}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3149326417299643767}
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
---- !u!33 &5968602274900620474
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2250339879979335594}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &4851144345488517393
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2250339879979335594}
+  m_GameObject: {fileID: 2039209275694103591}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8425885f0d262b0428350f0b0d850a11, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 539227d16cd76d24e9acd4b28d4b9daa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InteractionHint
+  Text: Buy
 --- !u!1 &5399742445194153375
 GameObject:
   m_ObjectHideFlags: 0
@@ -194,8 +120,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.2}
-  m_SizeDelta: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.3}
+  m_SizeDelta: {x: 2, y: 2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &7433063112793058186
 MeshRenderer:
@@ -292,8 +218,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 4
-  m_fontSizeBase: 4
+  m_fontSize: 6
+  m_fontSizeBase: 6
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Assets/Prefabs/Shop/Shop.prefab
+++ b/Assets/Prefabs/Shop/Shop.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7652874051074528184}
   - component: {fileID: 5783686499299264076}
   - component: {fileID: 6216808285261435324}
-  - component: {fileID: 2839271512150615960}
+  - component: {fileID: 2866433285772556758}
   m_Layer: 0
   m_Name: Shop
   m_TagString: Untagged
@@ -48,11 +48,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c1de7629195a51a6acf84ecf7aea865, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  itemDefinitions: {fileID: 0}
-  numItemSlots: 3
   itemSlotPrefab: {fileID: 2039209275694103591, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
   slotDisplayParent: {fileID: 3334482627787709302}
-  itemScale: {x: 0.1, y: 0.1, z: 0.1}
 --- !u!208 &6216808285261435324
 NavMeshObstacle:
   m_ObjectHideFlags: 0
@@ -63,14 +60,14 @@ NavMeshObstacle:
   m_Enabled: 1
   serializedVersion: 3
   m_Shape: 1
-  m_Extents: {x: 1, y: 0.35, z: 0.45}
+  m_Extents: {x: 0.45, y: 0.35, z: 1}
   m_MoveThreshold: 0.1
   m_Carve: 0
   m_CarveOnlyStationary: 1
   m_Center: {x: 0, y: 0.4, z: 0}
   m_TimeToStationary: 0.5
---- !u!65 &2839271512150615960
-BoxCollider:
+--- !u!64 &2866433285772556758
+MeshCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -87,9 +84,10 @@ BoxCollider:
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 2, y: 0.7, z: 0.9}
-  m_Center: {x: 0, y: 0.4, z: 0}
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -6692290496178104961, guid: 5706152116712a24a86964b405b41a0f, type: 3}
 --- !u!1 &8705672360542760137
 GameObject:
   m_ObjectHideFlags: 0
@@ -114,8 +112,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8705672360542760137}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.8, z: 0}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -123,7 +121,7 @@ Transform:
   - {fileID: 2258821923779121444}
   - {fileID: 5381177938514138162}
   m_Father: {fileID: 7652874051074528184}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1001 &3813516592103165011
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -135,18 +133,6 @@ PrefabInstance:
     - target: {fileID: 2039209275694103591, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_Name
       value: ItemSlot (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.z
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Center.z
-      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 3149326417299643767, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_LocalPosition.x
@@ -220,7 +206,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -228,7 +214,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalRotation.z
@@ -240,7 +226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5706152116712a24a86964b405b41a0f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -271,18 +257,6 @@ PrefabInstance:
     - target: {fileID: 2039209275694103591, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_Name
       value: ItemSlot (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.z
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Center.z
-      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 3149326417299643767, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_LocalPosition.x
@@ -345,18 +319,6 @@ PrefabInstance:
     - target: {fileID: 2039209275694103591, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_Name
       value: ItemSlot
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Size.z
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991341889146743818, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
-      propertyPath: m_Center.z
-      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 3149326417299643767, guid: 4374d672cac9fbb99938d0d63978e082, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Trapdoor.prefab
+++ b/Assets/Prefabs/Trapdoor.prefab
@@ -12,6 +12,8 @@ GameObject:
   - component: {fileID: 2776673878060333644}
   - component: {fileID: 8153539615784696594}
   - component: {fileID: 885248714058289575}
+  - component: {fileID: 3051982175118773285}
+  - component: {fileID: 3572420648559291412}
   m_Layer: 0
   m_Name: Trapdoor
   m_TagString: Untagged
@@ -54,8 +56,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2, y: 0.44, z: 2}
-  m_Center: {x: 0, y: 0.22, z: 0}
+  m_Size: {x: 2, y: 0.32, z: 2}
+  m_Center: {x: 0, y: 0.16, z: 0}
 --- !u!114 &8153539615784696594
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -68,6 +70,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf3d26f789942ef7dbba6e6e93a2f717, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::TrapDoor
+  closedInteractionText: Clear the level first
+  openInteractionText: Go to next level
 --- !u!114 &885248714058289575
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -81,6 +85,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::FloorClearing
   trapDoor: {fileID: 1259973537569220611}
+--- !u!114 &3051982175118773285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259973537569220611}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 539227d16cd76d24e9acd4b28d4b9daa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InteractionHint
+  Text: 
+--- !u!208 &3572420648559291412
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259973537569220611}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 1, y: 0.16, z: 1}
+  m_MoveThreshold: 0.1
+  m_Carve: 0
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0.16, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &8646655941658029441
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -133,9 +166,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ba0e00cf522635c4aa907a52e53f9eef, type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: ba0e00cf522635c4aa907a52e53f9eef, type: 3}
       propertyPath: m_Name
       value: Trapdoor
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ba0e00cf522635c4aa907a52e53f9eef, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Attachable.cs
+++ b/Assets/Scripts/Attachable.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+public class Attachable : MonoBehaviour
+{
+	public Transform attachedTo = null;
+
+	public void OnAttach(AttachedObjects target) {
+		attachedTo = target.gameObject.transform;
+
+        if (TryGetComponent<Rigidbody>(out Rigidbody rb)) {
+            rb.linearVelocity = Vector3.zero;
+            rb.angularVelocity = Vector3.zero;
+            rb.isKinematic = true;
+        }
+
+        if (TryGetComponent<Collider>(out Collider c)) {
+            c.enabled = false;
+        }
+	}
+
+	public void OnDetach() {
+		attachedTo = null;
+
+        if (TryGetComponent<Collider>(out Collider c)) {
+            c.enabled = true;
+        }
+
+        if (TryGetComponent<Rigidbody>(out Rigidbody rb)) {
+            rb.isKinematic = false;
+        }
+	}
+}
+

--- a/Assets/Scripts/Attachable.cs.meta
+++ b/Assets/Scripts/Attachable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9b7b4dc7e378fb5397ae934a4737e8a

--- a/Assets/Scripts/AttachedObjects.cs
+++ b/Assets/Scripts/AttachedObjects.cs
@@ -44,6 +44,10 @@ public class AttachedObjects : MonoBehaviour
     }
 
     protected int AttachTo(Transform obj, Transform target) {
+        if (maximumAttachedObjects == 0) {
+            return -1;
+        }
+
         // if overwriting, detach first
         if (attachedObjects[index] != null)
             OnDetach(attachedObjects[index]);

--- a/Assets/Scripts/AttachedObjects.cs
+++ b/Assets/Scripts/AttachedObjects.cs
@@ -1,18 +1,20 @@
 using UnityEngine;
 
+// class for managing objects that are temporarily attached to others (e.g. projectiles that have hit something)
 public class AttachedObjects : MonoBehaviour
 {
+    // ring buffer size
     public int maximumAttachedObjects = 10;
-    public SkinnedMeshRenderer mesh;
- 
-    // 
-    private int index = 0;
-    private Transform[] bones;
-    private Transform[] attachedObjects;
-    private Vector3[] offsets;
-    private Quaternion[] rotations;
- 
-    bool visible = true;
+
+    // information for each attached object
+    protected int index = 0;
+    protected Transform[] attachmentTargets;
+    protected Transform[] attachedObjects;
+    protected Vector3[] offsets;
+    protected Quaternion[] rotations;
+
+    // only update positions when visible
+    protected bool visible = true;
  
     void OnBecameInvisible() {
         visible = false;
@@ -21,74 +23,77 @@ public class AttachedObjects : MonoBehaviour
     void OnBecameVisible() {
         visible = true;
     }
- 
-    void Start() {
-        bones = new Transform[maximumAttachedObjects];
+
+    void Update() {
+        if (!visible) return;
+
+        UpdatePositions();
+    }
+
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    public AttachedObjects()
+    {
         attachedObjects = new Transform[maximumAttachedObjects];
- 
+        attachmentTargets = new Transform[maximumAttachedObjects];
         offsets = new Vector3[maximumAttachedObjects];
         rotations = new Quaternion[maximumAttachedObjects];
     }
- 
-    public void Attach(Transform obj) {
-        if (mesh == null) return;
 
-        Transform bone = mesh.bones[0];
-        float sqrDist = float.MaxValue;
-        foreach (var b in mesh.bones) {
-            float d = b.InverseTransformPoint(obj.position).sqrMagnitude;
-            if (d < sqrDist) {
-                bone = b;
-                sqrDist = d;
-            }
-        }
+    public virtual void Attach(Transform obj) {
+        AttachTo(obj, transform);
+    }
 
+    protected int AttachTo(Transform obj, Transform target) {
         // if overwriting, detach first
         if (attachedObjects[index] != null)
             OnDetach(attachedObjects[index]);
 
         attachedObjects[index] = obj;
-        bones[index] = bone;
+        attachmentTargets[index] = target;
 
-        offsets[index] = bone.InverseTransformPoint(obj.position);
-        rotations[index] =  Quaternion.Inverse(bone.rotation) * obj.rotation;
+        offsets[index] = target.InverseTransformPoint(obj.position);
+        rotations[index] =  Quaternion.Inverse(target.rotation) * obj.rotation;
 
         // call attachement function
         OnAttach(attachedObjects[index]);
 
+        int result = index;
         index = (index + 1) % maximumAttachedObjects;
+        return result;
     }
 
-    void OnAttach(Transform obj) {
+    protected void UpdatePositions() {
+        for (int i = 0; i < maximumAttachedObjects; i++) {
+            if (attachedObjects[i] == null || attachmentTargets[i] == null) continue;
+
+            attachedObjects[i].SetPositionAndRotation(attachmentTargets[i].TransformPoint(offsets[i]),  attachmentTargets[i].rotation * rotations[i]);
+        }
+    }
+
+    protected void DetachAll() {
+        // update positions now if not done during update function
+        if (!visible) UpdatePositions();
+
+        for (int i = 0; i < maximumAttachedObjects; i++) {
+            if (attachedObjects[i] == null || attachmentTargets[i] == null) continue;
+
+            OnDetach(attachedObjects[i]);
+        }
+    }
+
+    void OnDestroy() {
+        DetachAll();
+    }
+
+    protected void OnAttach(Transform obj) {
 	    if (obj.TryGetComponent<Attachable>(out Attachable a)) {
 	    	a.OnAttach(this);
 	    }
     }
 
-    void OnDetach(Transform obj) {
+    protected void OnDetach(Transform obj) {
 	    if (obj.TryGetComponent<Attachable>(out Attachable a)) {
 	    	a.OnDetach();
 	    }
     }
-
-    // Update is called once per frame
-    void Update()
-    {
-        if (!visible) return;
-
-        for (int i = 0; i < maximumAttachedObjects; i++) {
-            if (attachedObjects[i] == null || bones[i] == null) continue;
-
-            attachedObjects[i].SetPositionAndRotation(bones[i].TransformPoint(offsets[i]),  bones[i].rotation * rotations[i]);
-        }
-    }
-
-    void OnDestroy() {
-        for (int i = 0; i < maximumAttachedObjects; i++) {
-            if (attachedObjects[i] == null || bones[i] == null) continue;
-
-            OnDetach(attachedObjects[i]);
-        }
-    }
 }
-

--- a/Assets/Scripts/AttachedObjects.cs
+++ b/Assets/Scripts/AttachedObjects.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+
+public class AttachedObjects : MonoBehaviour
+{
+    public int maximumAttachedObjects = 10;
+    public SkinnedMeshRenderer mesh;
+ 
+    // 
+    private int index = 0;
+    private Transform[] bones;
+    private Transform[] attachedObjects;
+    private Vector3[] offsets;
+    private Quaternion[] rotations;
+ 
+    bool visible = true;
+ 
+    void OnBecameInvisible() {
+        visible = false;
+    }
+ 
+    void OnBecameVisible() {
+        visible = true;
+    }
+ 
+    void Start() {
+        bones = new Transform[maximumAttachedObjects];
+        attachedObjects = new Transform[maximumAttachedObjects];
+ 
+        offsets = new Vector3[maximumAttachedObjects];
+        rotations = new Quaternion[maximumAttachedObjects];
+    }
+ 
+    public void Attach(Transform obj) {
+        if (mesh == null) return;
+
+        Transform bone = mesh.bones[0];
+        float sqrDist = float.MaxValue;
+        foreach (var b in mesh.bones) {
+            float d = b.InverseTransformPoint(obj.position).sqrMagnitude;
+            if (d < sqrDist) {
+                bone = b;
+                sqrDist = d;
+            }
+        }
+
+        // if overwriting, detach first
+        if (attachedObjects[index] != null)
+            OnDetach(attachedObjects[index]);
+
+        attachedObjects[index] = obj;
+        bones[index] = bone;
+
+        offsets[index] = bone.InverseTransformPoint(obj.position);
+        rotations[index] =  Quaternion.Inverse(bone.rotation) * obj.rotation;
+
+        // call attachement function
+        OnAttach(attachedObjects[index]);
+
+        index = (index + 1) % maximumAttachedObjects;
+    }
+
+    void OnAttach(Transform obj) {
+	    if (obj.TryGetComponent<Attachable>(out Attachable a)) {
+	    	a.OnAttach(this);
+	    }
+    }
+
+    void OnDetach(Transform obj) {
+	    if (obj.TryGetComponent<Attachable>(out Attachable a)) {
+	    	a.OnDetach();
+	    }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (!visible) return;
+
+        for (int i = 0; i < maximumAttachedObjects; i++) {
+            if (attachedObjects[i] == null || bones[i] == null) continue;
+
+            attachedObjects[i].SetPositionAndRotation(bones[i].TransformPoint(offsets[i]),  bones[i].rotation * rotations[i]);
+        }
+    }
+
+    void OnDestroy() {
+        for (int i = 0; i < maximumAttachedObjects; i++) {
+            if (attachedObjects[i] == null || bones[i] == null) continue;
+
+            OnDetach(attachedObjects[i]);
+        }
+    }
+}
+

--- a/Assets/Scripts/AttachedObjects.cs.meta
+++ b/Assets/Scripts/AttachedObjects.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 52725cfa5a14fa803b3a1ba42ecf7fa1
+guid: e227e6af1d2a503c7846a56c901df237

--- a/Assets/Scripts/AttachedObjects.cs.meta
+++ b/Assets/Scripts/AttachedObjects.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52725cfa5a14fa803b3a1ba42ecf7fa1

--- a/Assets/Scripts/AttachedObjectsToBones.cs
+++ b/Assets/Scripts/AttachedObjectsToBones.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+public class AttachedObjectsToBones : AttachedObjects
+{
+    public SkinnedMeshRenderer mesh;
+
+    // decreases the distance to the selected bone by this factor
+    public float boneSnappingFactor;
+
+    // 
+    public override void Attach(Transform obj) {
+        if (mesh == null) {
+            base.Attach(obj);
+            return;
+        }
+
+        // find bone to attach to
+        Transform bone = mesh.bones[0];
+        float sqrDist = float.MaxValue;
+        foreach (var b in mesh.bones) {
+            float d = b.InverseTransformPoint(obj.position).sqrMagnitude;
+            if (d < sqrDist) {
+                bone = b;
+                sqrDist = d;
+            }
+        }
+
+
+        int idx = base.AttachTo(obj, bone);
+
+        offsets[idx] *= boneSnappingFactor;
+    }
+
+    void Update() {
+        if (visible)
+            base.UpdatePositions();
+    }
+
+    void OnDestroy() {
+        base.DetachAll();
+    }
+}
+

--- a/Assets/Scripts/AttachedObjectsToBones.cs
+++ b/Assets/Scripts/AttachedObjectsToBones.cs
@@ -27,8 +27,8 @@ public class AttachedObjectsToBones : AttachedObjects
 
 
         int idx = base.AttachTo(obj, bone);
-
-        offsets[idx] *= boneSnappingFactor;
+        if (idx > 0)
+            offsets[idx] *= boneSnappingFactor;
     }
 
     void Update() {

--- a/Assets/Scripts/AttachedObjectsToBones.cs.meta
+++ b/Assets/Scripts/AttachedObjectsToBones.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52725cfa5a14fa803b3a1ba42ecf7fa1

--- a/Assets/Scripts/Items/DroppedItem.cs
+++ b/Assets/Scripts/Items/DroppedItem.cs
@@ -5,6 +5,7 @@ public class DroppedItem : MonoBehaviour
     [Header("Rendering")]
     public Vector3 modelPosition;
     public Vector3 modelScale;
+    public Quaternion modelRotation;
 
     public ItemDefinition item {get; private set;}
     public int count {get; private set;}
@@ -13,9 +14,26 @@ public class DroppedItem : MonoBehaviour
         this.item = item;
         this.count = count;
 
+        // put item name into interaction hint
+        GetComponent<InteractionHint>().Text = $"Pick up({item.displayName})";
+
+        // instantiate prefab as child
         Transform instance = Instantiate(item.itemModel, transform).transform;
-        instance.localPosition = modelPosition;
-        instance.localScale = modelScale;
+        // instance.localPosition = modelPosition;
+        // instance.localScale = modelScale;
+        // instance.localRotation = modelRotation;
+
+        // compute extent of collider (box collider for ease of use)
+        BoxCollider myCollider = GetComponent<BoxCollider>();
+        if (instance.TryGetComponent<Collider>(out Collider coll)) {
+            Bounds bounds = coll.bounds;
+            myCollider.center = transform.InverseTransformPoint(bounds.center);
+            myCollider.size = bounds.size;
+        } else if (instance.TryGetComponent<MeshFilter>(out MeshFilter mesh)) {
+            Bounds bounds = mesh.mesh.bounds;
+            myCollider.center = bounds.center;
+            myCollider.size = bounds.size;
+        }
     }
 
     public void Disable() {

--- a/Assets/Scripts/Items/DroppedItem.cs
+++ b/Assets/Scripts/Items/DroppedItem.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System;
 
 public class DroppedItem : MonoBehaviour
 {
@@ -10,12 +11,14 @@ public class DroppedItem : MonoBehaviour
     public ItemDefinition item {get; private set;}
     public int count {get; private set;}
 
+    public string interactionHintFormat;
+
     public void SetItem(ItemDefinition item, int count) {
         this.item = item;
         this.count = count;
 
         // put item name into interaction hint
-        GetComponent<InteractionHint>().Text = $"Pick up({item.displayName})";
+        GetComponent<InteractionHint>().Text = String.Format(interactionHintFormat, item.displayName, count);
 
         // instantiate prefab as child
         Transform instance = Instantiate(item.itemModel, transform).transform;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -484,7 +484,7 @@ public class Player : MonoBehaviour
 
         items.ConsumeItem(bowAmmoSlot);
 
-        Vector3 position = cameraTransform.position + transform.forward * 1.0f;
+        Vector3 position = cameraTransform.position + cameraTransform.forward * 1.0f;
         Quaternion rotation = cameraTransform.rotation;
 
         Projectile instance = Instantiate(projectiles[0], position, rotation);

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -68,10 +68,14 @@ public class Player : MonoBehaviour
     public Weapon weapon;
     public PlayerHitZone hitZone;
 
+    [Header("Interaction")]
+    public float interactionDistance = 10f;
+
     private Inventory inventory;
     private Constitution constitution;
     private ItemDefinitions itemDefinitions;
     private PlayerStats stats;
+    private Crosshair crosshair;
 
     public bool isDead = false;
     private bool opponentGotHit;
@@ -81,6 +85,7 @@ public class Player : MonoBehaviour
         stats = GetComponent<PlayerStats>();
         inventory = GetComponent<Inventory>();
         constitution = GetComponent<Constitution>();
+        crosshair = GameObject.Find("Canvas/Crosshair").GetComponent<Crosshair>();
         itemDefinitions = GameObject.Find("Definitions").GetComponent<ItemDefinitions>();
 
         GameObject mainCamera = GameObject.Find("Main Camera");
@@ -88,7 +93,6 @@ public class Player : MonoBehaviour
         playerCamera = mainCamera.GetComponent<Camera>();
         cameraTransform = mainCamera.GetComponent<Transform>();
         characterController = GetComponent<CharacterController>();
-        interactArea = GameObject.Find("Interaction Area").GetComponent<InteractionArea>();
 
         leftShoulderTransform = GameObject.Find("Left Shoulder").GetComponent<Transform>();
         rightShoulderTransform = GameObject.Find("Right Shoulder").GetComponent<Transform>();
@@ -233,6 +237,15 @@ public class Player : MonoBehaviour
         constitution.RegenerateMana();
         bool idle = motion.x >= -0.1f && motion.x <= 0.1f && motion.y >= -0.1f && motion.y <= 0.1f && motion.z >= -0.1f && motion.z <= 0.1f;
         constitution.RegenerateStamina(idle);
+
+        // give interaction hint
+        if (RaycastInteractible(out RaycastHit hit)) {
+            if (hit.transform.gameObject.TryGetComponent<InteractionHint>(out InteractionHint hint)) {
+                crosshair.SetInteractionText(hint.Text);
+            } else {
+                crosshair.Reset();
+            }
+        }
     }
 
     public void Aim(bool value)
@@ -326,11 +339,9 @@ public class Player : MonoBehaviour
         endRotation = Quaternion.Euler(swingRotation);
     }
 
-
+    // use raycast to find object for interaction
     public bool RaycastInteractible(out RaycastHit hit) {
         Vector3 position = cameraTransform.position + cameraTransform.forward * 0.1f;
-        Debug.DrawRay(position, cameraTransform.forward, Color.white, 1.0f);
-        float interactionDistance = 10f;
         return Physics.Raycast(position, cameraTransform.forward, out hit, interactionDistance, ~LayerMask.GetMask("Player"));
     }
 
@@ -355,17 +366,8 @@ public class Player : MonoBehaviour
 
     public void Interact()
     {
-        bool done = false;
-
-        // first check interaction area
-        if (interactArea.triggerObject != null)
-        {
-            done = InteractWith(interactArea.triggerObject.transform);
-        }
-
-        // then try raycasting
-        if (!done && RaycastInteractible(out RaycastHit hit)) {
-            done = InteractWith(hit.transform);
+        if (RaycastInteractible(out RaycastHit hit)) {
+            InteractWith(hit.transform);
         }
     }
 

--- a/Assets/Scripts/PlayerHitZone.cs
+++ b/Assets/Scripts/PlayerHitZone.cs
@@ -24,16 +24,9 @@ public class PlayerHitZone : MonoBehaviour
 
         Debug.Log("Zone hit: " + name);
 
-        if (name.Contains("chest"))
-        {
-            Transform parent = other.gameObject.transform.parent;
-            DestroyableObject destroyableObject = parent.GetComponent<DestroyableObject>();
-
-            if (destroyableObject != null)
-            {
-                Debug.Log("Zone dealing " + damage + " damage to " + parent.name);
-                destroyableObject.TakeDamage(damage);
-            }
+        if (other.gameObject.TryGetComponent<DestroyableObject>(out DestroyableObject destroyableObject)) {
+            Debug.Log("Zone dealing " + damage + " damage to " + other.gameObject.name);
+            destroyableObject.TakeDamage(damage);
         }
 
         if (name.Contains("Opponent"))

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -86,17 +86,20 @@ public class Projectile : MonoBehaviour
             opponent.TakeDamage(damage);
         }
 
-        // arrow can penetrate opponent, so its position has be computed appropriately
+        // arrow can stick to opponent, so its position has be computed appropriately
         if (name.Contains("Opponent"))
         {
-            float penetrationFactor = 0.5f;
-            droppedInstance = Instantiate(droppedItemPrefab, hit.point - transform.TransformVector(tipPosition) + travelDirection.normalized * penetrationFactor, transform.GetChild(0).rotation);
+            Vector3 diffToOrthPlane = hit.transform.position - hit.point;
+            diffToOrthPlane.y = 0f;
+            Vector3 point = hit.point + travelDirection.normalized * Vector3.Dot(travelDirection.normalized, diffToOrthPlane);
+            droppedInstance = Instantiate(droppedItemPrefab, point, transform.GetChild(0).rotation);
             droppedInstance.GetComponent<DroppedItem>().SetItem(bowAmmo, 1);
             droppedInstance.name = bowAmmo.name;
         }
         else
         {
-            droppedInstance = Instantiate(droppedItemPrefab, hit.point - transform.TransformVector(tipPosition), transform.GetChild(0).rotation);
+            float depthFactor = 0.5f; // 1 means the arrow does not go into the hit object, -1 means it fully goes in
+            droppedInstance = Instantiate(droppedItemPrefab, hit.point - transform.TransformVector(tipPosition * depthFactor), transform.GetChild(0).rotation);
             droppedInstance.GetComponent<DroppedItem>().SetItem(bowAmmo, 1);
             droppedInstance.name = bowAmmo.name;
         }

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -21,6 +21,7 @@ public class Projectile : MonoBehaviour
     [Header("Properties")]
     public float speed;
     public float lifetime;
+    public Vector3 tipPosition;
 
     void Awake()
     {
@@ -81,7 +82,7 @@ public class Projectile : MonoBehaviour
         }
         else
         {
-            GameObject instance = Instantiate(droppedItemPrefab, this.transform.position, Quaternion.LookRotation(travelDirection));
+            GameObject instance = Instantiate(droppedItemPrefab, collision.GetContact(0).point - transform.TransformVector(tipPosition), transform.GetChild(0).rotation);
             instance.GetComponent<DroppedItem>().SetItem(bowAmmo, 1);
             instance.name = bowAmmo.name;
             Destroy(this.gameObject);

--- a/Assets/Scripts/TrapDoor.cs
+++ b/Assets/Scripts/TrapDoor.cs
@@ -5,8 +5,12 @@ public class TrapDoor : MonoBehaviour
 {
     private bool isEnabled = false;
 
+    public string closedInteractionText;
+    public string openInteractionText;
+
     public void Enable() {
         isEnabled = true;
+        GetComponent<InteractionHint>().Text = openInteractionText;
     }
 
     public void Interact()
@@ -17,4 +21,9 @@ public class TrapDoor : MonoBehaviour
         RunData.Instance.LevelDone();
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
+
+    void Start() {
+        GetComponent<InteractionHint>().Text = closedInteractionText;
+    }
+
 }

--- a/Assets/Scripts/UI/Crosshair.cs
+++ b/Assets/Scripts/UI/Crosshair.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class Crosshair : MonoBehaviour
+{
+    [SerializeField]
+    private Image icon;
+    [SerializeField]
+    private TMP_Text text;
+
+    private Sprite defaultSprite;
+    private string defaultText;
+
+
+    public void SetInteractionText(string interactionText) {
+        text.text = interactionText;
+    }
+
+    public void SetIcon(Sprite newIcon) {
+        icon.sprite = newIcon;
+    }
+
+    public void Reset() {
+        text.text = defaultText;
+        icon.sprite = defaultSprite;
+    }
+
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        defaultSprite = icon.sprite;
+        defaultText = text.text;
+        Reset();
+    }
+}

--- a/Assets/Scripts/UI/Crosshair.cs.meta
+++ b/Assets/Scripts/UI/Crosshair.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b1b264d8adc6151caa83d63bd8d45c2

--- a/Assets/Scripts/UI/InteractionHint.cs
+++ b/Assets/Scripts/UI/InteractionHint.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class InteractionHint : MonoBehaviour
+{
+    public string Text;
+}

--- a/Assets/Scripts/UI/InteractionHint.cs.meta
+++ b/Assets/Scripts/UI/InteractionHint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 539227d16cd76d24e9acd4b28d4b9daa

--- a/Assets/Scripts/UI/ItemHotbarSlot.cs
+++ b/Assets/Scripts/UI/ItemHotbarSlot.cs
@@ -18,7 +18,10 @@ public class ItemHotbarSlot : MonoBehaviour
         if (itemModel != null) Destroy(itemModel);
 
         if (count > 0 && item != null) {
-            itemModel = Instantiate(item.itemModelUI, transform);
+            if (item.itemModelUI != null)
+                itemModel = Instantiate(item.itemModelUI, transform);
+            else 
+                itemModel = null;
             itemText.GetComponent<TMP_Text>().text = item.displayName;
             itemCount.GetComponent<TMP_Text>().text = count.ToString();
         } else {


### PR DESCRIPTION
Adds a crosshair (a simple dot for now) to the canvas.

In addition, adds a text element next to it that can show text depending on the object the player looks at.

Refactors the prefabs for dropped items and shop item slots such that their colliders are set appropriately. In particular, this makes picking up arrows work as it should.

Further, includes enhancements to projectiles that stick to objects. E.g. arrows can now stick to chests and fall down when the chest is destroyed. Works similarly for enemies where arrows can stick to the bones (maximum number of attached arrows can be configured).