### PR TITLE
Filter items that can be placed in each inventory slot

### DIFF
--- a/Assets/Prefabs/Canvas.prefab
+++ b/Assets/Prefabs/Canvas.prefab
@@ -68,9 +68,9 @@ RectTransform:
   m_Father: {fileID: 5704610307999934279}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.8}
-  m_AnchoredPosition: {x: 0, y: 5}
-  m_SizeDelta: {x: -40, y: -10}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -25}
+  m_SizeDelta: {x: -40, y: -90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1941773121018138859
 GameObject:
@@ -84,7 +84,7 @@ GameObject:
   - component: {fileID: 979618859465515065}
   - component: {fileID: 7380680789581233529}
   m_Layer: 5
-  m_Name: Text
+  m_Name: ItemName
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -97,18 +97,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1941773121018138859}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4526810957335962497}
+  m_Father: {fileID: 5704610307999934279}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: -20}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: -60, y: 50}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &979618859465515065
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -169,8 +169,8 @@ MonoBehaviour:
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontSizeMax: 36
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
   m_textAlignment: 65535
@@ -378,9 +378,9 @@ RectTransform:
   m_Father: {fileID: 3213122476349767259}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -2.5, y: 0}
-  m_SizeDelta: {x: -5, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 10}
+  m_SizeDelta: {x: 0, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7466957799500598709
 CanvasRenderer:
@@ -961,8 +961,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -75}
-  m_SizeDelta: {x: -20, y: -85}
+  m_AnchoredPosition: {x: 0, y: -70}
+  m_SizeDelta: {x: -50, y: -95}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &5585583044631568344
 CanvasRenderer:
@@ -1104,7 +1104,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 900}
+  m_SizeDelta: {x: 900, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8086221433706150915
 MonoBehaviour:
@@ -1120,9 +1120,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::InventoryUI
   slotPrefab: {fileID: 7343116501942089031, guid: f84497dd88d73036ba3e58426918a475, type: 3}
   slotParent: {fileID: 485175064072412744}
-  slotPositionBotLeft: {fileID: 7057957628486490704}
-  slotPositionBotRight: {fileID: 1393018025772576906}
-  slotPositionTopLeft: {fileID: 9118884390214529491}
+  slotTransformBotLeft: {fileID: 7057957628486490704}
+  slotTransformBotRight: {fileID: 1393018025772576906}
+  slotTransformTopLeft: {fileID: 9118884390214529491}
   itemNameText: {fileID: 7380680789581233529}
   itemDescriptionText: {fileID: 8944336561309606877}
   itemBuffText: {fileID: 2419347362322737192}
@@ -1290,14 +1290,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4526810957335962497}
+  - {fileID: 5000906488263628400}
   - {fileID: 3213122476349767259}
   m_Father: {fileID: 4272778915715390304}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchorMin: {x: 0.6, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -50}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &5250011730722534877
 CanvasRenderer:
@@ -1404,10 +1404,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 229429181074842722}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -10}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: -60, y: 50}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1499154667193665398
 CanvasRenderer:
@@ -1467,12 +1467,12 @@ MonoBehaviour:
   m_fontSize: 36
   m_fontSizeBase: 36
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_fontSizeMax: 36
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -1941,7 +1941,7 @@ RectTransform:
   - {fileID: 6502810630639480516}
   m_Father: {fileID: 854983740755527331}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.66, y: 0}
+  m_AnchorMin: {x: 0.6, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -2403,6 +2403,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 229429181074842722}
+  - {fileID: 8622986383827119741}
+  - {fileID: 1478916222683482963}
   m_Father: {fileID: 7299883490974400925}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2423,8 +2425,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   statUIPrefab: {fileID: 4181095292343879397, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
-  origin: {x: -150, y: 260}
-  offset: {x: 0, y: -80}
+  statTransformStart: {fileID: 8622986383827119741}
+  statTransformEnd: {fileID: 1478916222683482963}
   statNameText: {fileID: 6302165386999173938}
   statInfoText: {fileID: 6366769092732951360}
 --- !u!114 &267371259086297132
@@ -2579,82 +2581,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &6087533788401797934
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4526810957335962497}
-  - component: {fileID: 7760768698603373984}
-  - component: {fileID: 2643284034526099453}
-  m_Layer: 5
-  m_Name: ItemName
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4526810957335962497
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6087533788401797934}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5000906488263628400}
-  m_Father: {fileID: 5704610307999934279}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.8}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -10}
-  m_SizeDelta: {x: -40, y: -20}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!222 &7760768698603373984
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6087533788401797934}
-  m_CullTransparentMesh: 1
---- !u!114 &2643284034526099453
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6087533788401797934}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.4117647}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6163778199094893067
 GameObject:
   m_ObjectHideFlags: 0
@@ -2763,10 +2689,10 @@ RectTransform:
   - {fileID: 212888548907441968}
   m_Father: {fileID: 3213122476349767259}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 2.5, y: 0}
-  m_SizeDelta: {x: -5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5269438762858268136
 CanvasRenderer:
@@ -3750,10 +3676,10 @@ RectTransform:
   - {fileID: 9118884390214529491}
   m_Father: {fileID: 4272778915715390304}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -25}
-  m_SizeDelta: {x: 0, y: -50}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.6, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1102400489553201821
 CanvasRenderer:
@@ -3793,3 +3719,207 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &2841601697482363066
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 854983740755527331}
+    m_Modifications:
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4181095292343879397, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Name
+      value: StatParent (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+--- !u!224 &1478916222683482963 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+  m_PrefabInstance: {fileID: 2841601697482363066}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4918581316435473812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 854983740755527331}
+    m_Modifications:
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4181095292343879397, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+      propertyPath: m_Name
+      value: StatParent
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+--- !u!224 &8622986383827119741 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3740608686759468009, guid: 8ab8870e4ce9871f99d59bd181fbcf79, type: 3}
+  m_PrefabInstance: {fileID: 4918581316435473812}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Definitions.prefab
+++ b/Assets/Prefabs/Definitions.prefab
@@ -52,6 +52,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Constants
   itemSlots: 12
   hotbarSlots: 4
+  inventoryMask: 05000000050000000500000005000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   initialGold: 5
   initialXP: 0
   initialAmmo: 16

--- a/Assets/Prefabs/UI/ClickableSlot.prefab
+++ b/Assets/Prefabs/UI/ClickableSlot.prefab
@@ -228,15 +228,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
+  m_fontSize: 14
   m_fontSizeBase: 24
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 9
+  m_fontSizeMax: 14
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Prefabs/UI/Slot.prefab
+++ b/Assets/Prefabs/UI/Slot.prefab
@@ -228,15 +228,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
+  m_fontSize: 14
   m_fontSizeBase: 24
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 9
+  m_fontSizeMax: 14
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Scenes/LevelScene.unity
+++ b/Assets/Scenes/LevelScene.unity
@@ -176,6 +176,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 61894679d4d1cdc45bf55da6b032d215, type: 3}
+--- !u!114 &62124511 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1174493148950342287, guid: 758dd1d80f8f28e41b779b0989e997e1, type: 3}
+  m_PrefabInstance: {fileID: 2113634165}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9238566f73bd5d5df8f0abf244b9260d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UIManager
 --- !u!114 &635671204 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7704773253529878811, guid: 0a53e9d4b436e9f239d561d2ef7c9a96, type: 3}
@@ -246,6 +257,18 @@ MonoBehaviour:
       - m_Target: {fileID: 904684438}
         m_TargetAssemblyTypeName: Player, Assembly-CSharp
         m_MethodName: StartGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 62124511}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: SwitchToGameplay
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/Constants.cs
+++ b/Assets/Scripts/Constants.cs
@@ -5,8 +5,23 @@ public class Constants : MonoBehaviour
     public int itemSlots;
     public int hotbarSlots;
 
+    public ItemType[] inventoryMask;
+
     // definitions for new run
     public int initialGold;
     public int initialXP;
     public int initialAmmo;
+
+    public void OnValidate() 
+    {
+        if (!(hotbarSlots >= 0 && hotbarSlots <= itemSlots))
+        {
+            Debug.LogError("hotbarSlots has be positive and smaller than itemSlots");
+        }
+
+        if(inventoryMask.Length != hotbarSlots)
+        {
+            Debug.LogError("length of inventoryMask has to be equal to itemSlots");
+        }
+    }
 }

--- a/Assets/Scripts/Items/Inventory.cs
+++ b/Assets/Scripts/Items/Inventory.cs
@@ -5,16 +5,17 @@ using System.Collections.Generic;
 
 public class Inventory : MonoBehaviour
 {
-    public int numHotbarSlots  {get; private set;}
-    public int numItemSlots {get => container.slots.Length;}
-    public ItemContainer container { get; private set;}
+    public int numHotbarSlots  {get; protected set;}
+    public int numItemSlots {get => items.slots.Length;}
+    public ItemContainer items { get; protected set;}
+    private ItemType[] mask;
 
     // amount of currencies
-    public int numCurrencySlots {get; private set;} = Enum.GetValues(typeof(Currency)).Length;
-    public CurrencyContainer currency { get; private set; }
+    public int numCurrencySlots {get; protected set;} = Enum.GetValues(typeof(Currency)).Length;
+    public CurrencyContainer currency { get; protected set; }
 
     public Inventory() {
-        container = RunData.Instance.items;
+        items = RunData.Instance.items;// new(RunData.Instance.items, mask);
         currency = RunData.Instance.currencies;
 
         GameSaver.subscribe(currency);
@@ -23,6 +24,17 @@ public class Inventory : MonoBehaviour
     public void Start() {
         Constants defs = GameObject.Find("Definitions").GetComponent<Constants>();
         numHotbarSlots = defs.hotbarSlots;
+        mask = defs.inventoryMask;
+    }
+
+    public void AddCurrency(Currency currency, int amount) 
+    {
+        this.currency[currency] += amount;
+    }
+
+    public void AddItem(ItemDefinition item, int count) 
+    {
+        items.AddItem(item, count, mask);
     }
 }
 
@@ -51,7 +63,7 @@ public class CurrencyContainer {
 }
 
 public class ItemContainer {
-    public ItemSlot[] slots {get; private set;} = new ItemSlot[0];
+    public ItemSlot[] slots {get; protected set;} = new ItemSlot[0];
 
     public ItemSlot this[int slot] {
         get => slots[slot];
@@ -104,7 +116,6 @@ public class ItemContainer {
             if(slots[slot].count == 0)
                 slots[slot].storedItem = null;
         }
-        PrintState();
     }
 
     // returns the number of items that have been added to the slot
@@ -118,7 +129,6 @@ public class ItemContainer {
         int actualCount = (remainingSpace < count) ? remainingSpace : count;
         slots[slot].count += actualCount;
 
-        PrintState();
         return actualCount;
     }
 
@@ -146,19 +156,65 @@ public class ItemContainer {
         return -1;
     }
 
-    public int GetSlotContaining(ItemDefinition item, int requiredAmount = 1) {
-        for (int i = 0; i < slots.Length; i++) {
-            if (slots[i].storedItem == item && slots[i].count >= requiredAmount) {
+    public int GetSlotContaining(ItemDefinition item, int requiredAmount = 1) 
+    {
+        for (int i = 0; i < slots.Length; i++) 
+        {
+            if (slots[i].storedItem == item && slots[i].count >= requiredAmount) 
+            {
                 return i;
             }
         }
         return -1;
     }
 
-    public int GetFreeSlot() {
-        for (int i = 0; i < slots.Length; i++) {
+    public int GetFreeSlot() 
+    {
+        for (int i = 0; i < slots.Length; i++) 
+        {
             if (slots[i].count == 0)
                 return i;
+        }
+        return -1;
+    }
+
+    // Selects an appropriate slot to add item, i.e. either a slot containing same item type or a free one
+    public void AddItem(ItemDefinition item, int count, ItemType[] mask) 
+    {
+        while (count > 0) 
+        {
+            int slot = GetSlotWithCapacity(item, 1);
+
+            if (slot < 0)
+            {
+                slot = GetFreeSlotFor(item, mask);
+            }
+
+            if (slot >= 0) 
+            {
+                count -= AddItem(slot, item, count);
+            }
+            else
+            {    // no free slots
+                count = 0;
+            }
+        }
+    }
+
+
+    public int GetFreeSlotFor(ItemDefinition item, ItemType[] mask)
+    {
+        for (int i = 0; i < slots.Length; i++) 
+        {
+            if (mask != null && i < mask.Length && (item.type & mask[i]) == 0) 
+            {
+                continue;
+            }
+
+            if (slots[i].count == 0)
+            {
+                return i;
+            }
         }
         return -1;
     }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -381,13 +381,13 @@ public class Player : MonoBehaviour
     public bool InteractWith(Transform transform) {
         if (transform.gameObject.TryGetComponent<ShopItemSlot>(out ShopItemSlot slot)) {
             if (inventory.currency[Currency.Gold] < slot.item.cost) return false;
-            inventory.currency[Currency.Gold] -= slot.item.cost;
-            inventory.container.AddItem(slot.item, slot.count);
+            inventory.AddCurrency(Currency.Gold, -slot.item.cost);
+            inventory.AddItem(slot.item, slot.count);
             slot.shop.RemoveItem(slot.Index);
             OnInventoryChanged();
             return true;
         } else if (transform.gameObject.TryGetComponent<DroppedItem>(out DroppedItem item)) {
-            inventory.container.AddItem(item.item, item.count);
+            inventory.AddItem(item.item, item.count);
             item.Disable();
             OnInventoryChanged();
             return true;
@@ -512,7 +512,7 @@ public class Player : MonoBehaviour
 
     public void Shoot()
     {
-        ItemContainer items = inventory.container;
+        ItemContainer items = inventory.items;
         int bowAmmoSlot = items.GetSlotContaining(itemDefinitions[3], 1);
 
         if (fireCooldown > 0.0f || projectiles.Length == 0 || bowAmmoSlot == -1)
@@ -562,7 +562,7 @@ public class Player : MonoBehaviour
 
     public void UseItem(int itemID)
     {
-        ItemContainer inv = GetComponent<Inventory>().container;
+        ItemContainer inv = GetComponent<Inventory>().items;
         ItemSlot slot = inv[itemID];
         ItemDefinition item = slot.storedItem;
         int count = slot.count;

--- a/Assets/Scripts/PlayerStats/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats/PlayerStats.cs
@@ -20,7 +20,7 @@ public class PlayerStats : MonoBehaviour
     public float Compute(StatKey stat) {
         float value = def[stat].ComputeFrom(upgrades.levels);
 
-        foreach (var slot in inventory.container.slots)
+        foreach (var slot in inventory.items.slots)
         {
             if (slot.storedItem == null) continue;
             var buff = slot.storedItem.itemBuffs[stat];

--- a/Assets/Scripts/RunData.cs
+++ b/Assets/Scripts/RunData.cs
@@ -51,7 +51,7 @@ public class RunData {
         constitution.mana = PlayerStats.ComputeInitial(StatKey.MaxMana, statDef, upgrades);
 
         // add initial items and currencies
-        items.AddItem(defs.GetComponent<ItemDefinitions>()[3], constants.initialAmmo);
+        items.AddItem(defs.GetComponent<ItemDefinitions>()[3], constants.initialAmmo, constants.inventoryMask);
         currencies[Currency.Gold] = constants.initialGold;
     }
 
@@ -80,7 +80,7 @@ public class RunData {
         constitution.mana = PlayerStats.ComputeInitial(StatKey.MaxMana, statDef, upgrades);
 
         // add initial items and currencies
-        items.AddItem(defs.GetComponent<ItemDefinitions>()[3], constants.initialAmmo);
+        items.AddItem(defs.GetComponent<ItemDefinitions>()[3], constants.initialAmmo, constants.inventoryMask);
         currencies[Currency.Gold] = constants.initialGold;
         currencies[Currency.XP] = constants.initialXP;
     }

--- a/Assets/Scripts/UI/InventoryUI.cs
+++ b/Assets/Scripts/UI/InventoryUI.cs
@@ -15,14 +15,9 @@ public class InventoryUI : MonoBehaviour
     public Transform slotParent;
 
     // transforms that define slot positions
-    public RectTransform slotPositionBotLeft;
-    public RectTransform slotPositionBotRight;
-    public RectTransform slotPositionTopLeft;
-
-    // positions
-    private Vector2 slotPositionOrigin;
-    private Vector2 slotPositionRight;
-    private Vector2 slotPositionBottom;
+    public RectTransform slotTransformBotLeft;
+    public RectTransform slotTransformBotRight;
+    public RectTransform slotTransformTopLeft;
 
     [Header("Selected Item")]
     public TMP_Text itemNameText;
@@ -35,7 +30,8 @@ public class InventoryUI : MonoBehaviour
 
     // selection state
     public int currentSlot;
-    public bool grabbed;
+    private int grabbedSourceSlot;
+    private bool grabbed { get => grabbedSourceSlot >= 0; }
 
     // instantiated slots
     private GameObject[] slots = null;
@@ -80,20 +76,26 @@ public class InventoryUI : MonoBehaviour
     }
 
     void InitializeSlots() {
+        grabbedSourceSlot = -1;
         numSlots = inventory.numItemSlots;
         numHotbarSlots = inventory.numHotbarSlots;
         slots = new GameObject[numSlots];
 
         for (int i = 0; i < numSlots; i++) {
             slots[i] = Instantiate(slotPrefab, slotParent);
-            // left-to-right
+
+            // coefficients
+            int numRows = numSlots / numColumns;
             float right = (float)(i % numColumns) / (numColumns - 1);
-            Vector2 pos = slotPositionOrigin + slotPositionRight * right;
-            // top-to-bottom
-            float down = (float)(i / numColumns) / (float)Math.Ceiling((double)numSlots / numColumns - 1);
-            pos += slotPositionBottom * down;
-            // slots[i].GetComponent<RectTransform>().anchoredPosition = pos;
-            slots[i].transform.localPosition = pos;
+            float up = (float)(i / numColumns) / (numRows - 1);
+
+            // lerp position
+            Vector2 pos1 = Vector2.Lerp(slotTransformBotLeft.localPosition, slotTransformBotRight.localPosition, right);
+            Vector2 pos2 = Vector2.Lerp(slotTransformBotLeft.localPosition, slotTransformTopLeft.localPosition, up);
+
+            // slotTransformBotLeft has been added twice, so subtract it once here
+            RectTransform target = slots[i].GetComponent<RectTransform>();
+            target.localPosition = pos1 + pos2 - (Vector2)slotTransformBotLeft.localPosition;
         }
     }
 
@@ -101,7 +103,22 @@ public class InventoryUI : MonoBehaviour
         for (int i = 0; i < slots.Length; i++) {
             GameObject slot = slots[i];
             ItemHotbarSlot s = slot.GetComponent<ItemHotbarSlot>();
-            s.SetItem(inventory.items[i].storedItem, inventory.items[i].count);
+
+            ItemSlot slotToShow = inventory.items[i];
+            // if currently moving an item, show preview of items after swap
+            if (grabbed)
+            {
+                if (i == currentSlot)
+                {
+                    slotToShow = inventory.items[grabbedSourceSlot];
+                }
+                else if (i == grabbedSourceSlot)
+                {
+                    slotToShow = inventory.items[currentSlot];
+                }
+            }
+
+            s.SetItem(slotToShow.storedItem, slotToShow.count);
             s.SetSelected(i == currentSlot);
             slot.GetComponent<Button>().onClick.AddListener(delegate { OnClick(i); });
         }
@@ -116,43 +133,39 @@ public class InventoryUI : MonoBehaviour
 
     private void SwitchSlot(bool right) {
         int newSlot = right ? ((currentSlot + 1 + numSlots) % numSlots) : (currentSlot - 1 + numSlots) % numSlots;
-        if (grabbed)
-            inventory.items.SwapItems(currentSlot, newSlot);
         currentSlot = newSlot;
+
+        UpdateSlots();
     }
 
     public void MoveSelection(Vector2 delta) {
         if (numSlots == 0) return;
         int newSlot = (currentSlot + (int)Math.Round(delta.x) + numSlots) % numSlots;
         newSlot = (newSlot + (int)Math.Round(delta.y) * numColumns + numSlots) % numSlots;
-        if (grabbed)
-            inventory.items.SwapItems(currentSlot, newSlot);
         currentSlot = newSlot;
+
+        UpdateSlots();
     }
 
     public void ToggleItemGrabbed() {
-        grabbed = !grabbed;
+        if (grabbed)
+        {
+            inventory.items.SwapItems(currentSlot, grabbedSourceSlot);
+            grabbedSourceSlot = -1;
+        }
+        else 
+        {
+            grabbedSourceSlot = currentSlot;
+        }
+
+        UpdateSlots();
     }
 
-    void Start() {
+    void OnEnable() {
         player = GameObject.Find("Player").GetComponent<Player>();
         inventory = GameObject.Find("Player").GetComponent<Inventory>();
-    }
-
-    void Awake() {
-        slotPositionOrigin = slotPositionBotLeft.localPosition;
-        slotPositionRight  = slotPositionBotRight.localPosition;
-        slotPositionRight -= slotPositionOrigin;
-        slotPositionBottom = slotPositionTopLeft.localPosition;
-        slotPositionBottom-= slotPositionOrigin;
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        // check if slot count has changed
-        numSlots = inventory.numItemSlots;
-        if (slots == null || numSlots != slots.Length)
+    
+        if (slots == null || slots.Length != inventory.numItemSlots)
             InitializeSlots();
 
         UpdateSlots();

--- a/Assets/Scripts/UI/InventoryUI.cs
+++ b/Assets/Scripts/UI/InventoryUI.cs
@@ -40,9 +40,9 @@ public class InventoryUI : MonoBehaviour
     {
         if (item == null)
         {
-            itemNameText.text = "";
-            itemDescriptionText.text = "";
-            itemBuffText.text = "";
+            itemNameText.text = "Nothing";
+            itemDescriptionText.text = "This is a free slot in your bag";
+            itemBuffText.text = "...";
             return;
         }
 

--- a/Assets/Scripts/UI/InventoryUI.cs
+++ b/Assets/Scripts/UI/InventoryUI.cs
@@ -101,12 +101,12 @@ public class InventoryUI : MonoBehaviour
         for (int i = 0; i < slots.Length; i++) {
             GameObject slot = slots[i];
             ItemHotbarSlot s = slot.GetComponent<ItemHotbarSlot>();
-            s.SetItem(inventory.container[i].storedItem, inventory.container[i].count);
+            s.SetItem(inventory.items[i].storedItem, inventory.items[i].count);
             s.SetSelected(i == currentSlot);
             slot.GetComponent<Button>().onClick.AddListener(delegate { OnClick(i); });
         }
 
-        ItemSlot selected = inventory.container[currentSlot];
+        ItemSlot selected = inventory.items[currentSlot];
         UpdateSelectedItem(selected.storedItem, selected.count);
     }
 
@@ -117,7 +117,7 @@ public class InventoryUI : MonoBehaviour
     private void SwitchSlot(bool right) {
         int newSlot = right ? ((currentSlot + 1 + numSlots) % numSlots) : (currentSlot - 1 + numSlots) % numSlots;
         if (grabbed)
-            inventory.container.SwapItems(currentSlot, newSlot);
+            inventory.items.SwapItems(currentSlot, newSlot);
         currentSlot = newSlot;
     }
 
@@ -126,7 +126,7 @@ public class InventoryUI : MonoBehaviour
         int newSlot = (currentSlot + (int)Math.Round(delta.x) + numSlots) % numSlots;
         newSlot = (newSlot + (int)Math.Round(delta.y) * numColumns + numSlots) % numSlots;
         if (grabbed)
-            inventory.container.SwapItems(currentSlot, newSlot);
+            inventory.items.SwapItems(currentSlot, newSlot);
         currentSlot = newSlot;
     }
 

--- a/Assets/Scripts/UI/ItemHotbar.cs
+++ b/Assets/Scripts/UI/ItemHotbar.cs
@@ -45,14 +45,17 @@ public class ItemHotbar : MonoBehaviour
         }
     }
 
-    // Update is called once per frame
-    void Update()
+    void OnEnable() 
     {
         // check if slot count has changed
         int numSlots = Math.Min(playerInventory.numHotbarSlots, playerInventory.numItemSlots);
         if (slots == null || numSlots != slots.Length)
             InitializeSlots();
+    }
 
+    // Update is called once per frame
+    void Update()
+    {
         UpdateSlots();
     }
 }

--- a/Assets/Scripts/UI/ItemHotbar.cs
+++ b/Assets/Scripts/UI/ItemHotbar.cs
@@ -40,7 +40,7 @@ public class ItemHotbar : MonoBehaviour
         for (int i = 0; i < slots.Length; i++) {
             GameObject slot = slots[i];
             ItemHotbarSlot s = slot.GetComponent<ItemHotbarSlot>();
-            s.SetItem(playerInventory.container[i].storedItem, playerInventory.container[i].count);
+            s.SetItem(playerInventory.items[i].storedItem, playerInventory.items[i].count);
             s.SetSelected(false);
         }
     }

--- a/Assets/Scripts/UI/ItemHotbar.cs
+++ b/Assets/Scripts/UI/ItemHotbar.cs
@@ -15,7 +15,8 @@ public class ItemHotbar : MonoBehaviour
     // 
     private GameObject[] slots;
 
-    public void Awake() {
+    public void Awake() 
+    {
         player = GameObject.Find("Player");
         playerInventory = player.GetComponent<Inventory>();
     }
@@ -45,17 +46,14 @@ public class ItemHotbar : MonoBehaviour
         }
     }
 
-    void OnEnable() 
+    // Update is called once per frame
+    void Update()
     {
         // check if slot count has changed
         int numSlots = Math.Min(playerInventory.numHotbarSlots, playerInventory.numItemSlots);
         if (slots == null || numSlots != slots.Length)
             InitializeSlots();
-    }
 
-    // Update is called once per frame
-    void Update()
-    {
         UpdateSlots();
     }
 }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -129,9 +129,7 @@ public class UIManager : MonoBehaviour
             actions[i].action = InputSystem.actions.FindAction(actions[i].name, true);
         }
 
-        SwitchToGameplay();
     }
-
 
     private void ApplyState() {
         UpdateVisibility();

--- a/Assets/Scripts/UI/UpgradeUI.cs
+++ b/Assets/Scripts/UI/UpgradeUI.cs
@@ -8,8 +8,10 @@ public class UpgradeUI : MonoBehaviour
 {
     [Header("Rendering")]
     public GameObject statUIPrefab;
-    public Vector2 origin;
-    public Vector2 offset;
+
+    // transforms that define slot positions
+    public RectTransform statTransformStart;
+    public RectTransform statTransformEnd;
 
     [Header("Stat information")]
     public TMP_Text statNameText;
@@ -31,11 +33,13 @@ public class UpgradeUI : MonoBehaviour
     public void MoveSelection(Vector2 delta) 
     {
         selectedIndex = (selectedIndex - (int)delta.y + stats.Length) % stats.Length;
+        UpdateUpgrades();
     }
 
     public void TryUpgrade() 
     {  
         upgrades.TryUpgrade(selectedStat);
+        UpdateUpgrades();
     }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
@@ -45,24 +49,34 @@ public class UpgradeUI : MonoBehaviour
         scalingDefs = GameObject.Find("Definitions").GetComponent<StatScalingDefinitions>();
         player = GameObject.Find("Player");
         upgrades = player.GetComponent<PlayerUpgrades>();
+    }
 
+    void OnEnable() 
+    {
         // clear old ui objects
-        if (uiInstances != null) {
-            foreach (var i in uiInstances) 
-                GameObject.Destroy(i);
-        } else {
+        if (uiInstances == null) {
             uiInstances = new GameObject[stats.Length];
         }
 
-        // 
+        // create ui element for each stat
         int index = 0;
         foreach(BaseStatKey key in stats) {
+            if (uiInstances[index] != null) continue;
+
             var obj = Instantiate(statUIPrefab, transform);
-            obj.transform.localPosition = origin + offset * index;
+            RectTransform target = obj.GetComponent<RectTransform>();
+            target.localPosition = Vector2.Lerp(statTransformStart.localPosition, statTransformEnd.localPosition, (float)index / (stats.Length - 1));
+            target.localScale    = Vector2.Lerp(statTransformStart.localScale, statTransformEnd.localScale, (float)index / (stats.Length - 1));
 
             uiInstances[index] = obj;
             index++;
         }
+
+        // disable preview gameobjects
+        statTransformStart.gameObject.SetActive(false);
+        statTransformEnd.gameObject.SetActive(false);
+
+        UpdateUpgrades();
     }
 
     public void UpdateUpgrades() {
@@ -105,10 +119,5 @@ public class UpgradeUI : MonoBehaviour
         }
 
         return builder.ToString();
-    }
-
-    void Update() {
-        // TODO: extract to player script
-        UpdateUpgrades();
     }
 }

--- a/Assets/Scripts/UserInput.cs
+++ b/Assets/Scripts/UserInput.cs
@@ -65,7 +65,7 @@ public class UserInput : MonoBehaviour
     [Tooltip("How fast the ui should be navigated (in Hz)")]
     public float uiNavigateRepeatRate;
 
-    void Awake()
+    void Start()
     {
         player = GameObject.Find("Player").GetComponent<Player>();
         playerUpgrades = GameObject.Find("Player").GetComponent<PlayerUpgrades>();


### PR DESCRIPTION
Adds a mask to the inventory that specifies which types of items can be placed in each slot.

Uses this mask to disallow ammunition to  be stored in hotbar.

Improves item dragging in the inventory such that items can be arbitrarily swapped. 

Also streamlines ui updates, such that these don't have to be performed on each Update()-call.